### PR TITLE
propose some changes to the OCM API to move forward to a version 1.0

### DIFF
--- a/spec.yaml
+++ b/spec.yaml
@@ -15,7 +15,7 @@ parameters:
   id:
     name: id
     in: path
-    description:  Unique ID to identify the share at the consumer side.
+    description: Unique ID to identify the share at the consumer side.
     required: true
     type: string
   page:
@@ -24,339 +24,126 @@ parameters:
     type: integer
     required: false
     default: 1
-    description: |
-      Default parameter to handle paging through collections. However, this parameter is NOT mandatory, as clients should use
-      the HAL navigation links (e.g. `_links.next.href`) to paginate. These links enable the possibility to use vendor specific pagination.
+    description: >
+      Default parameter to handle paging through collections. However, this
+      parameter is NOT mandatory, as clients should use
+
+      the HAL navigation links (e.g. `_links.next.href`) to paginate. These
+      links enable the possibility to use vendor specific pagination.
 paths:
-  /shares/{id}:
-    get:
-      summary: Retreive a single share
-      description: |
-        With this call the provider can retreive a single share it created at the consumer side. This is a convenience call 
-        which could be used to check whether everything is still in sync etc.
-      parameters:
-        - $ref: '#/parameters/id'
-      responses:
-        200:
-          description: Representation of the single share.
-          schema:
-            $ref: "#/definitions/Share"
-        401:
-          description: Client cannot be authenticated as a trusted service.
-          schema:
-            $ref: "#/definitions/Error"            
-        403:
-          description: Trusted service is not authorized to retreive one of it's shares.
-          schema:
-            $ref: "#/definitions/Error"
-        404:
-          description: The share cannot be found, probably due to a non-existing id.
-          schema:
-            $ref: "#/definitions/Error"
-        501:
-          description: The consumer doesn't support exposing single shares.
-          schema:
-            $ref: "#/definitions/Error"
-        503:
-          description: The consumer is temporary unavailable (e.g. due to planned maintenance).
-          headers:
-            Retry-After:
-              description: |
-                Indication for the client when the service could be requested again in HTTP Date format as used by the 
-                Internet Message Format [RFC5322] (e.g. `Wed, 21 Oct 2015 07:28:00 GMT`) or the number of seconds 
-                (e.g. 3000 if you the service is expected to be available again within 50 minutes).
-              type: string
-          schema:
-            $ref: "#/definitions/Error"
   /shares:
-    get:
-      summary: Retreive all shares
-      description: |
-        With this call the provider can retreive all shares it created at the consumer side. This is a convenience call 
-        which could be used to check whether everything is still in sync etc.
-      parameters:
-        - $ref: '#/parameters/page'
-      responses:
-        200:
-          description: HAL-paginated collection of all shares.
-          headers:
-            X-Page:
-              description: Number of the current page.
-              type: number
-              format: integer
-            X-Per-Page:
-              description: Number of items per page returned.
-              type: number
-              format: integer
-            X-Total:
-              description: Number of total shares matching the filter criteria.
-              type: number
-              format: integer
-          schema:
-            type: object
-            required: [_embedded, _links]
-            properties:
-              _embedded:
-                type: object
-                properties:
-                  shares:
-                    type: array
-                    items:
-                      $ref: "#/definitions/Share"
-              _links:
-                type: object
-                required: [self]
-                properties:
-                  self:
-                    type: object
-                    required: [href]
-                    properties:
-                      href:
-                        type: string
-                        description: Link to current page.
-                        example: /shares
-                  next:
-                    type: object
-                    required: [href]
-                    properties:
-                      href:
-                        type: string
-                        description: Link to next page in the collection.
-                        example: /shares?page=2
-        401:
-          description: Client cannot be authenticated as a trusted service.
-          schema:
-            $ref: "#/definitions/Error"            
-        403:
-          description: Trusted service is not authorized to retreive it's shares.
-          schema:
-            $ref: "#/definitions/Error"
-        501:
-          description: The consumer doesn't support exposing shares.
-          schema:
-            $ref: "#/definitions/Error"
-        503:
-          description: The consumer is temporary unavailable (e.g. due to planned maintenance).
-          headers:
-            Retry-After:
-              description: |
-                Indication for the client when the service could be requested again in HTTP Date format as used by the 
-                Internet Message Format [RFC5322] (e.g. `Wed, 21 Oct 2015 07:28:00 GMT`) or the number of seconds 
-                (e.g. 3000 if you the service is expected to be available again within 50 minutes).
-              type: string
-          schema:
-            $ref: "#/definitions/Error"
     post:
       summary: Create a new share
-      description: |
-        After the provider created a local share, it sends a `share` object to the consumer containing the 
-        information which is needed to start synchronization between the two services.
+      description: >
+        After the provider created a local share, it sends a `share` object to
+        the consumer containing the 
+
+        information which is needed to start synchronization between the two
+        services.
       parameters:
         - name: share
           in: body
           description: The JSON object to create a new share at the consumer side.
           required: true
           schema:
-            $ref: "#/definitions/NewShare"
+            $ref: '#/definitions/NewShare'
       responses:
-        201:
-          description: Consumer succesfully received the share and responds with the created unique identifier and datetime of the processed share.
-          headers:
-            Location:
-              description: |
-                The URI where the newly created share can be found at the consumer side (e.g. `/shares/3819`).
-              type: string
+        '201':
+          description: Consumer succesfully received the share.
+        '400':
+          description: >
+            Bad request due to invalid parameters, e.g. when `shareWith` is not
+            found or required properties are missing.
           schema:
-            $ref: "#/definitions/Share"
-        400:
-          description: |
-            Bad request due to invalid parameters, e.g. when `shareWith` is not found or required properties are missing.
-          schema:
-            $ref: "#/definitions/400"
-        401:
+            $ref: '#/definitions/400'
+        '401':
           description: Client cannot be authenticated as a trusted service.
           schema:
-            $ref: "#/definitions/Error"            
-        403:
+            $ref: '#/definitions/Error'
+        '403':
           description: Trusted service is not authorized to create shares.
           schema:
-            $ref: "#/definitions/Error"
-        501:
-          description: The consumer doesn't support incoming external shares.
+            $ref: '#/definitions/Error'
+        '501':
+          description: >-
+            The consumer doesn't support incoming external shares, the share
+            type or the resource type is not supported.
           schema:
-            $ref: "#/definitions/Error"
-        503:
-          description: The consumer is temporary unavailable (e.g. due to planned maintenance).
+            $ref: '#/definitions/Error'
+        '503':
+          description: >-
+            The consumer is temporary unavailable (e.g. due to planned
+            maintenance).
           headers:
             Retry-After:
-              description: |
-                Indication for the client when the service could be requested again in HTTP Date format as used by the 
-                Internet Message Format [RFC5322] (e.g. `Wed, 21 Oct 2015 07:28:00 GMT`) or the number of seconds 
-                (e.g. 3000 if you the service is expected to be available again within 50 minutes).
+              description: >
+                Indication for the client when the service could be requested
+                again in HTTP Date format as used by the 
+
+                Internet Message Format [RFC5322] (e.g. `Wed, 21 Oct 2015
+                07:28:00 GMT`) or the number of seconds 
+
+                (e.g. 3000 if you the service is expected to be available again
+                within 50 minutes).
               type: string
           schema:
-            $ref: "#/definitions/Error"
-  /notifications/{id}:
-    get:
-      summary: Retreive a single notification
-      description: |
-        With this call the sender can retreive a single notification it created at the receiver side. This is a convenience call 
-        which could be used to check whether everything is still in sync etc.
-      parameters:
-        - $ref: '#/parameters/id'
-      responses:
-        200:
-          description: Representation of the single notification.
-          schema:
-            $ref: "#/definitions/Notification"
-        401:
-          description: Client cannot be authenticated as a trusted service.
-          schema:
-            $ref: "#/definitions/Error"            
-        403:
-          description: Trusted service is not authorized to retreive one of it's notifications.
-          schema:
-            $ref: "#/definitions/Error"
-        404:
-          description: The notification cannot be found, probably due to a non-existing id.
-          schema:
-            $ref: "#/definitions/Error"
-        501:
-          description: The receiver doesn't support exposing single notifications.
-          schema:
-            $ref: "#/definitions/Error"
-        503:
-          description: The receiver is temporary unavailable (e.g. due to planned maintenance).
-          headers:
-            Retry-After:
-              description: |
-                Indication for the client when the service could be requested again in HTTP Date format as used by the 
-                Internet Message Format [RFC5322] (e.g. `Wed, 21 Oct 2015 07:28:00 GMT`) or the number of seconds 
-                (e.g. 3000 if you the service is expected to be available again within 50 minutes).
-              type: string
-          schema:
-            $ref: "#/definitions/Error"            
+            $ref: '#/definitions/Error'
   /notifications:
-    get:
-      summary: Retreive all notifications
-      description: |
-        With this call the sender can retreive all notifications it created at the receiver side. This is a convenience call 
-        which could be used to check whether everything is still in sync etc.
-      parameters:
-        - $ref: '#/parameters/page'
-      responses:
-        200:
-          description: HAL-paginated collection of all notifications.
-          headers:
-            X-Page:
-              description: Number of the current page.
-              type: number
-              format: integer
-            X-Per-Page:
-              description: Number of items per page returned.
-              type: number
-              format: integer
-            X-Total:
-              description: Number of total notifications matching the filter criteria.
-              type: number
-              format: integer
-          schema:
-            type: object
-            required: [_embedded, _links]
-            properties:
-              _embedded:
-                type: object
-                properties:
-                  notifications:
-                    type: array
-                    items:
-                      $ref: "#/definitions/Notification"
-              _links:
-                type: object
-                required: [self]
-                properties:
-                  self:
-                    type: object
-                    required: [href]
-                    properties:
-                      href:
-                        type: string
-                        description: Link to current page.
-                        example: /notifications
-                  next:
-                    type: object
-                    required: [href]
-                    properties:
-                      href:
-                        type: string
-                        description: Link to next page in the collection.
-                        example: /notifications?page=2
-        401:
-          description: Client cannot be authenticated as a trusted service.
-          schema:
-            $ref: "#/definitions/Error"            
-        403:
-          description: Trusted service is not authorized to retreive it's notifications.
-          schema:
-            $ref: "#/definitions/Error"
-        501:
-          description: The receiver doesn't support exposing notifications.
-          schema:
-            $ref: "#/definitions/Error"
-        503:
-          description: The receiver is temporary unavailable (e.g. due to planned maintenance).
-          headers:
-            Retry-After:
-              description: |
-                Indication for the client when the service could be requested again in HTTP Date format as used by the 
-                Internet Message Format [RFC5322] (e.g. `Wed, 21 Oct 2015 07:28:00 GMT`) or the number of seconds 
-                (e.g. 3000 if you the service is expected to be available again within 50 minutes).
-              type: string
-          schema:
-            $ref: "#/definitions/Error"                        
     post:
       summary: Send a notification to a trusted service
-      description: Should be used to be 'polite', e.g. to let the provider know that a user has removed the share.
+      description: >-
+        Should be used to be 'polite', e.g. to let the provider know that a user
+        has removed the share.
+      parameters:
+        - name: notification
+          in: body
+          description: The JSON object with a new notification
+          required: true
+          schema:
+            $ref: '#/definitions/NewNotification'
       responses:
-        201:
-          description: Receiver succesfully received the notification and responds with the created unique identifier and datetime of the processed notification.
-          headers:
-            Location:
-              description: |
-                The URI where the newly created notification can be found at the receiver side (e.g. `/notifications/9303`).
-              type: string          
+        '201':
+          description: Receiver succesfully received the notification. The response body can contain a JSON object with some resonse data, depending on the specification of the actual notification.
+        '400':
+          description: >
+            Bad request due to invalid parameters, e.g. when `type` is invalid
+            or missing.
           schema:
-            $ref: "#/definitions/Notification"
-        400:
-          description: |
-            Bad request due to invalid parameters, e.g. when `type` is invalid or missing.
-          schema:
-            $ref: "#/definitions/400"            
-        401:
+            $ref: '#/definitions/400'
+        '401':
           description: Client cannot be authenticated as a trusted service.
           schema:
-            $ref: "#/definitions/Error"
-        403:
+            $ref: '#/definitions/Error'
+        '403':
           description: Trusted service is not authorized to create notifications.
           schema:
-            $ref: "#/definitions/Error"
-        501:
-          description: The receiver doesn't support notifications.
+            $ref: '#/definitions/Error'
+        '501':
+          description: >-
+            The receiver doesn't support notifications, the resource type is not
+            supported.
           schema:
-            $ref: "#/definitions/Error"
-        503:
-          description: The receiver is temporary unavailable (e.g. due to planned maintenance).
+            $ref: '#/definitions/Error'
+        '503':
+          description: >-
+            The receiver is temporary unavailable (e.g. due to planned
+            maintenance).
           headers:
             Retry-After:
-              description: |
-                Indication for the client when the service could be requested again in HTTP Date format as used by the 
-                Internet Message Format [RFC5322] (e.g. `Wed, 21 Oct 2015 07:28:00 GMT`) or the number of seconds 
-                (e.g. 3000 if you the service is expected to be available again within 50 minutes).
+              description: >
+                Indication for the client when the service could be requested
+                again in HTTP Date format as used by the 
+
+                Internet Message Format [RFC5322] (e.g. `Wed, 21 Oct 2015
+                07:28:00 GMT`) or the number of seconds 
+
+                (e.g. 3000 if you the service is expected to be available again
+                within 50 minutes).
               type: string
           schema:
-            $ref: "#/definitions/Error"
+            $ref: '#/definitions/Error'
 definitions:
-  400:
+  '400':
     type: object
     allOf:
       - $ref: '#/definitions/Error'
@@ -371,29 +158,48 @@ definitions:
                   example: shareWith
                 message:
                   type: string
-                  description: |
-                    A validation error message which is understandable for both humans and machines (e.g. no use of 
-                    special characters) providing more information on the cause of the validation error.
+                  description: >
+                    A validation error message which is understandable for both
+                    humans and machines (e.g. no use of 
+
+                    special characters) providing more information on the cause
+                    of the validation error.
                   example: NOT_FOUND
   Error:
     type: object
-    required: [message]
+    required:
+      - message
     properties:
       message:
         type: string
-        description: |
-          An error message which is understandable for both humans and machines (e.g. no use of 
-          special characters) providing more information on the cause of the error.
+        description: >
+          An error message which is understandable for both humans and machines
+          (e.g. no use of 
+
+          special characters) providing more information on the cause of the
+          error.
         example: RESOURCE_NOT_FOUND
   NewShare:
     type: object
-    required: [shareWith, name, providerId, owner, protocol]
+    required:
+      - shareWith
+      - name
+      - providerId
+      - owner
+      - protocol
+      - permission
+      - shareType
+      - resourceType
     properties:
       shareWith:
         type: string
-        description: |
-          Consumer specific identifier of the user or group the provider wants to share the resource with. 
-          This is known in advance. Please note that the consumer service endpoint is known in advance as 
+        description: >
+          Consumer specific identifier of the user or group the provider wants
+          to share the resource with. 
+
+          This is known in advance. Please note that the consumer service
+          endpoint is known in advance as 
+
           well, so this is no part of the request body.
         example: peter.szegedi@geant.org
       name:
@@ -403,106 +209,113 @@ definitions:
       description:
         type: string
         description: Optional description of the resource (file or folder).
-        example: This is the Open API Specification file (in YAML format) of the Open Cloud Mesh API.
+        example: >-
+          This is the Open API Specification file (in YAML format) of the Open
+          Cloud Mesh API.
       providerId:
         type: string
-        description: Identifier to identify the resource at the provider side. This is unique per provider.
+        description: >-
+          Identifier to identify the resource at the provider side. This is
+          unique per provider.
         example: 7c084226-d9a1-11e6-bf26-cec0c932ce01
       owner:
         description: |
-          Provider specific identifier of the user that wants to share the resource. Please note that the 
-          requesting provider is being identified on a higher level, so the former `remote` property 
-          is no part of the request body.
+          Provider specific identifier of the user who owns the resource.
         type: string
         example: dimitri@apiwise.nl
+      sender:
+        description: >
+          Provider specific identifier of the user that wants to share the
+          resource. Please note that the 
+
+          requesting provider is being identified on a higher level, so the
+          former `remote` property 
+
+          is no part of the request body.
+        type: string
+        example: john@apiwise.nl
+      ownerDisplayName:
+        type: string
+        description: |
+          Display name of the owner of the resource
+        example: Dimitri
+      senderDisplayName:
+        type: string
+        description: |
+          Display name of the owner of the resource
+        example: John Doe
+      shareType:
+        type: string
+        description: |
+          Share type (user or group share)
+        example: user
+      resourceType:
+        type: string
+        description: |
+          Resource type (file, calendar, contact,...)
+        example: file
       protocol:
         type: object
-        description: |
-          The protocol which is used to establish synchronisation. At the moment only `webdav` is 
+        description: >
+          The protocol which is used to establish synchronisation. At the moment
+          only `webdav` is 
+
           supported, but other (custom) protocols might be added in the future.
-        required: [name, options]
+        required:
+          - name
+          - options
         properties:
           name:
             type: string
-            description: |
-              The name of the protocol which is used to establish synchronisation. At the moment only `webdav` is 
-              supported, but other (custom) protocols might be added in the future.
-            enum: ['webdav']
+            description: >
+              The name of the protocol which is used to establish
+              synchronisation. At the moment only `webdav` is 
+
+              supported, but other (custom) protocols might be added in the
+              future.
+            enum:
+              - webdav
             example: webdav
           options:
             type: object
-            description: |
-              JSON object with protocol specific options, e.g. `uri`, `access_token`, `password`, `permissions` etc. At the moment
-              only `webdav` options are supported, but other (custom) protocol options might be added in the future.
+            description: >
+              JSON object with protocol specific options, e.g. `uri`,
+              `access_token`, `password`, `permissions` etc. At the moment
+
+              only `webdav` options are supported, but other (custom) protocol
+              options might be added in the future. For backward compatibility the webdav protocol will use the 'sharedSecret" as username and password
             example:
-              username: dimitri
-              permissions: 31
-  Share:
-    type: object
-    required: [id, createdAt, _links]
-    allOf:
-      - $ref: '#/definitions/NewShare'
-      - properties:
-          id:
-            type: string
-            description: Unique ID to identify the share at the consumer side.
-            example: 3819
-          createdAt:
-            type: string
-            format: datetime
-            description: Datetime when the share was created at the consumer side (ISO 8601).
-            example: "2016-12-05T15:06:58Z"
-          _links:
-            type: object
-            required: [self]
-            properties:
-              self:
-                type: object
-                required: [href]
-                properties:
-                  href:
-                    type: string
-                    description: Link to this specific share.
-                    example: /shares/3819
+              sharedSecret: "hfiuhworzwnur98d3wjiwhr"
+              permissions: "{http://open-cloud-mesh.org/ns}share-permissions"
   NewNotification:
     type: object
-    required: [type]
+    required:
+      - notificationType
+      - resourceType
+      - message
     properties:
-      type:
+      notificationType:
+        type: string
+        description: >
+          A notification type which is understandable for both humans and
+          machines (e.g. no use of 
+
+          special characters) providing more information on the cause of the
+          error.
+        example: SHARE_ACCEPTED
+      resourceType:
         type: string
         description: |
-          A notification type which is understandable for both humans and machines (e.g. no use of 
-          special characters) providing more information on the cause of the error.
-        example: SHARE_REMOVED    
-      message:
+          A resource type (e.g. file, calendar, contact)
+        example: file
+      providerId:
         type: string
-        description: An optional message to add more context to the notification (e.g. the reson why 
-          the consuming user removed the share).
-        example: I don't want to use this share anymore.
-  Notification:
-    type: object
-    required: [id, createdAt]
-    allOf:
-      - $ref: '#/definitions/NewNotification'
-      - properties:
-          id:
-            type: string
-            description: Unique ID to identify the notification at the receiving side.
-            example: 9303
-          createdAt:
-            type: string
-            format: datetime
-            description: Datetime when the notification was created at the receiving side (ISO 8601).
-            example: "2016-12-05T15:06:58Z"
-          _links:
-            type: object
-            required: [self]
-            properties:
-              self:
-                type: object
-                required: [href]
-                properties:
-                  href:
-                    type: string
-                    description: Link to this specific notification.
-                    example: /notifications/9303            
+        description: ID of the resource on the provider side
+        example: 7c084226-d9a1-11e6-bf26-cec0c932ce01
+      notification:
+        type: object
+        description: >
+          optional additional parameters, depending on the notification and the resource type
+        example:
+          message: "Recipient accepted the share"
+          sharedSecret: "hfiuhworzwnur98d3wjiwhr"

--- a/spec.yaml
+++ b/spec.yaml
@@ -49,7 +49,14 @@ paths:
             $ref: '#/definitions/NewShare'
       responses:
         '201':
-          description: Consumer succesfully received the share.
+          description: Consumer successfully received the share. The response might contain the display name of the recipient of the share for general user experience improvement
+          schema:
+            type: object
+            properties:
+              recipientDisplayName:
+                type: string
+                description: display name of the recipient
+                example: John Doe
         '400':
           description: >
             Bad request due to invalid parameters, e.g. when `shareWith` is not


### PR DESCRIPTION
some of you might remember my talk at the last CS3 conference where I presented Nextcloud's plans to implement the OCM API. As I already mentioned there and discussed with multiple stakeholders we can't implement the current version 0.3.0 directly but need to add some small improvements and clarification to meet our ambitious goal of a general cloud federation platform. Other cloud solutions seems to have similar challenges. Over the last weeks and months we worked at a first implementation at Nextcloud which lead to some (mostly small) changes and improvements which I would like to discuss with you. Many of this changes could be optional, I will mention it in the details below. But I would highly suggest to make most parameters mandatory as otherwise all implementation will have to distinguish between many different combination of parameters and handle them correctly. A complexity I would like to avoid in favor of a user-friendly API.

# End-Point discovery:

OCM should be used by a wide range of cloud solutions, as such we can't assume that everyone can implement a tld/share end-point. Sometimes this might not be possible for technical reasons, some projects might have dedicated paths for their public APIs and would like to keep it for consistency, some might already use this end-point for something different, etc. Therefore I think we need some kind of end-point discovery. My suggesting:

## Sending a GET request to /ocm-provider/ should return:

````
{
  "enabled":true,
  "apiVersion":"1.0-proposal1",
  "endPoint":"http://localhost/server/index.php/ocm",
  "resourceTypes": [
    {
      "name": "file",
      "shareTypes": ["user", "group"],
      "protocols": {
        "webdav":"http://localhost/server/public.php/webdav/"
      }
    }
  ],
}
````

In this example http://localhost/server/index.php/ocm would be the root for all the end-points defined in the API specification. You can easily find out which API version and which share types are supported because in the future at least some implementations don't want to limit themselves to files. Additional we use it to tell the server which protocol is supported to exchange the shared data and the end-point of the protocol.

# Sending a share:

I modified the POST request to send a share to look like this:

````
{
  "shareWith": "peter.szegedi@geant.org",
  "name": "spec.yaml",
  "description": "This is the Open API Specification file",
  "providerId": "7c084226-d9a1-11e6-bf26-cec0c932ce01",
  "owner": "dimitri@apiwise.nl",
  "sender": "john@apiwise.nl",
  "ownerDisplayName": "Dimitri",
  "senderDisplayName": "John Doe",
  "shareType": "user",
  "resourceType": "file",
  "protocol": {
    "name": "webdav",
    "options": {
      "sharedSecret": "hfiuhworzwnur98d3wjiwhr"
      "permissions": "{http://open-cloud-mesh.org/ns}share-permissions",
    }
  }
}
````

## Distinguish between sender and owner

In case of a re-share i think it is often beneficial to distinguish between the person who created the share and the person who owns the resource. Therefore I added a "sender", this could be optional and we just fall-back to sender=owner if no explicit sender is given.

## Allow display names

While the technical user ID's "user@server" are perfect to identify the user and the location, they are not really user-friendly. In the user interface you most likely want to show a real nane. Therefore I
added "senderDisplayName" and "ownerDisplayName" 

## shareType

We should be able to distinguish between different share types, the most obvious are "user" and "group" shares. But maybe in the future there might be more pop up. Therefore I added "shareType", if the server receives a share with a unknown share type, the server can just return 501 (not implemented)

During discussions at the CS3 many stakeholders raised the wish t use something more human readable then integers. That's why I added now the "permissions" filed which contains just a array with the values "read", "write", "share". Of course every share should at least come with "read" permissions.

## resourceType

This specifies the resource type. So far we only have file sharing, in case no resource type is given we could fall back to "file", although I would prefer to have this always explicite. In the future some implementations might provide additional resourceTypes, for which they might specify the "protocol" part so that other could implement it as well in a interoperable way. If a server received a share for a unknown resourceType it returns 501.

## Protocol

For the webdav protocol we should make sure that we chose a specification which is backward compatible to all the shares that already exists between Pydio, ownCloud, CernBox and Nextcloud. Other protocol can be implemented freely in the future. If a implementation want to provide additional "resourceType", they also need the specify the correspondig protocl block.

### sharedSecret

This is used as both username and password when mounting a federated share via webdav. It will be also used for notifications to authenticate against the remote server.

### Permissions

For permissions I would suggest to define a webdav property, so that the receiving side can query the permissions with a propfind at any time. We could either let the sender define the webdav property (as defined in this example) or we agree on one property name everybody should use. 

During discussion at the CS3 many people raised the wish to move away from the integer based permissions to something more human readable. So I would suggest that the propfind should return a JSON encoded array which can have the parameters "read", "write", and "share".

## Return codes

On success we return 201, the body can contain the display name of the recipient for general user experience improvements (this way user facing strings can show the nice human readable display name instead of the technical cloud id). The providerId (in combination with the server URL of the owner) and the shared secret are always the two identifier of a specific share on both sides.

If a resourceType or a shareType is not known we return 501, not implemented together with a message which parameter is unknown.

# Send a notification

I modified the post request to send a notification to look like this:

````
{
  "notificationType": "SHARE_REMOVED",
  "resourceType": "file",
  "providerId": "7c084226-d9a1-11e6-bf26-cec0c932ce01",
  "notification": {"message" : "I don't want to use this share anymore."}
}
````

## notificationType

the type of the notification, same as in version 0.0.3

## resourceType

like above we specify to which kind of resource the message belong to, for now only "file" is supported but it might change in the future for some implementation. If a message is received for a unknown resource, the server can just return 501.

## providerId

specifies to which share the notification belong to.

## notification

depending on the share type and and notification we might send additional information, this goes in the "notification", see some examples below. That's basically the payload of the notification.

### message

A human readable message which the receiving side could display to the user.

## Return codes

On success we return 201. Optionally the response body can contain a JSON object with some response data.

# Defining notifications

While notifications should be optional, I think we should define a set of notifications for the file sharing case. Otherwise everyone will implement their own slightly different notification and we will end up in a incompatible mess of notifications. Same goes for other resourceTypes, as soon as someone introduces a new resource type they should define a set of possible notifications which can be used for communication.

For file sharing we suggest this set of notifications:

````
{
  "notificationType": "SHARE_ACCEPTED",
  "resourceType": "file",
  "providerId": "7c084226-d9a1-11e6-bf26-cec0c932ce01",
  "notification": {
                    "sharedSecret": "hfiuhworzwnur98d3wjiwhr",
                    "message": "Recipient accepted the share"
                  }
}
````

````
{
  "notificationType": "SHARE_DECLINED",
  "resourceType": "file",
  "providerId": "7c084226-d9a1-11e6-bf26-cec0c932ce01",
  "notification": {
                    "sharedSecret": "hfiuhworzwnur98d3wjiwhr",
                    "message": "Recipient declined the share or unshared it from themself"
                  }
}
````

````
{
  "notificationType": "SHARE_UNSHARED",
  "resourceType": "file",
  "providerId": "7c084226-d9a1-11e6-bf26-cec0c932ce01",
  "notification": {
                    "sharedSecret": "hfiuhworzwnur98d3wjiwhr",
                    "message": "File was unshared"
                  }
}
````

````
{
  "notificationType": "REQUEST_RESHARE",
  "resourceType": "file",
  "providerId": "7c084226-d9a1-11e6-bf26-cec0c932ce01",
  "notification": {
                    "sharedSecret": "hfiuhworzwnur98d3wjiwhr", 
                    "shareWith": "peter.szegedi@geant.org",
                    "senderId": "9r48fh78-8r94f893-89483u89fh3",
                    "message": "Recipient of a share ask the owner to reshare the file with peter.szegedi@geant.org"
                  },
}
````

If the owner performs the requested reshare it will return the sharedSecret it created for the recipient together with the providerId. The secret is used both, to communicate with the receiver directly and to authenticate any follow-up message with the owner regarding the re-share

````
{
  "notificationType": "RESHARE_UNDO",
  "resourceType": "file",
  "providerId": "7c084226-d9a1-11e6-bf26-cec0c932ce01",
  "notification": {
                    "sharedSecret": "hfiuhworzwnur98d3wjiwhr",
                    "message": "Tell the owner (or the sender of a reshare) that the reshare was unshared"
                  }
}
````

````
{
  "notificationType": "RESHARE_CHANGE_PERMISSION",
  "resourceType": "file",
  "providerId": "7c084226-d9a1-11e6-bf26-cec0c932ce01",
  "notification": {
                    "sharedSecret": "hfiuhworzwnur98d3wjiwhr",
                    "permission": ["read", "write", "share"],
                    "message": "Tell the owner (or the sender of the reshare) that the permmissions changed"
                  },
}
````

As a acknowledgment that the share was received we return 201. If a notificationType or a resourceType is unknown on the receiving side we return 501 together with a message which kind of parameter is unknown.

# GET requests

For the first proposal I removed all the GET requests. During implementation I had no real use case for it and I also can't think about any. Keeping a history of all messages, share requests, etc could even be seen of a privacy issue. So why store stuff and provide an end-point to retrieve them again, if it is not really needed? If I missed something and someone come up with some real use cases, I'm happy to bring them back. Until then, let's keep the API as light as possible. 

# General

Please see this as a first draft open for discussion. Stuff can and most likely will change in this process. The main goal was to come up with something which works with all the existing implementations out there in a backward compatible way and to clarify some stuff from version 0.0.3. As a outcome it would be great to have a version 1.0 of the specification, implemented (or at least possible to implement) by the key stakeholders. I'm looking forward to your feedback.
