### PR TITLE
Improved properties of the NewShare endpoint + some more cleanup

### DIFF
--- a/spec.yaml
+++ b/spec.yaml
@@ -283,14 +283,14 @@ definitions:
           Other custom protocols might be added in the future.
         example:
           webdav:
-            sharedSecret: "hfiuhworzwnur98d3wjiwhr"
+            sharedSecret: "secret"
             permissions: ["read", "write", "share"]
             uri: "https://open-cloud-mesh.org/remote.php/webdav/path/to/resource"
           webapp:
-            sharedSecret: "hfiuhworzwnur98d3wjiwhr"
-            uriTemplate: "https://open-cloud-mesh.org/s/rglsertgsrt/{relative-path-to-shared-resource}"
+            sharedSecret: "secret"
+            uriTemplate: "https://open-cloud-mesh.org/s/{share-id}/{relative-path-to-shared-resource}"
           datatx:
-            sharedSecret: "hfiuhworzwnur98d3wjiwhr"
+            sharedSecret: "secret"
             srcUri: "https://open-cloud-mesh.org/remote.php/webdav/path/to/resource"
             size: 1000000000000
   NewNotification:

--- a/spec.yaml
+++ b/spec.yaml
@@ -48,7 +48,16 @@ paths:
       responses:
         "201":
           description: >
-            Consumer successfully received the share.
+            Consumer successfully received the share. The response might contain
+            the display name of the recipient of the share for general
+            user experience improvement.
+          schema:
+            type: object
+            properties:
+              recipientDisplayName:
+                type: string
+                description: display name of the recipient
+                example: John Doe
         "400":
           description: >
             Bad request due to invalid parameters, e.g. when `shareWith` is not
@@ -202,6 +211,7 @@ definitions:
       - shareWith
       - name
       - resourceId
+      - providerId
       - owner
       - sender
       - protocols
@@ -232,6 +242,12 @@ definitions:
         description: >
           Identifier to identify the resource at the provider side. This is
           unique per provider.
+        example: 7c084226-d9a1-11e6-bf26-cec0c932ce01
+      providerId:
+        type: string
+        description: >
+          Identifier to identify the resource at the provider side. This is
+          unique per provider (deprecated).
         example: 7c084226-d9a1-11e6-bf26-cec0c932ce01
       owner:
         description: |

--- a/spec.yaml
+++ b/spec.yaml
@@ -151,7 +151,11 @@ paths:
   /invite-accepted:
     post:
       summary: Inform the sender that the invitation was accepted to start sharing.
-      description: Inform about an accepted invitation so the user on the sender provider's side can initiate the OCM share creation.
+      description: >
+        Inform about an accepted invitation so the user on the sender provider's side can initiate the OCM share creation.
+        To protect the identity of the parties, for shares created following an OCM invitation,
+        the user id SHALL be hashed, and recipients implementing the OCM invitation workflow
+        MAY refuse to process shares coming from unknown parties.
       parameters:
         - name: invite
           in: body
@@ -226,7 +230,7 @@ definitions:
           to share the resource with. This is known in advance.
           Please note that the consumer service endpoint is known in advance
           as well, so this is no part of the request body.
-        example: peter.szegedi@geant.org
+        example: 51dc30ddc473d43a6011e9ebba6ca770@geant.org
       name:
         type: string
         description: Name of the resource (file or folder).
@@ -253,7 +257,7 @@ definitions:
         description: |
           Provider specific identifier of the user who owns the resource.
         type: string
-        example: dimitri@apiwise.nl
+        example: 6358b71804dfa8ab069cf05ed1b0ed2a@apiwise.nl
       sender:
         description: >
           Provider specific identifier of the user that wants to share the
@@ -261,7 +265,7 @@ definitions:
           identified on a higher level, so the former `remote` property
           is not part of the request body.
         type: string
-        example: john@apiwise.nl
+        example: 527bd5b5d689e2c32ae974c6229ff785@apiwise.nl
       ownerDisplayName:
         type: string
         description: |
@@ -394,7 +398,7 @@ definitions:
           userID:
             type: string
             description: Unique ID to identify the user at the remote provider accepting the invite.
-            example: 9303
+            example: 51dc30ddc473d43a6011e9ebba6ca770
           email:
             type: string
             description: Email ID of the user accepting the invite.

--- a/spec.yaml
+++ b/spec.yaml
@@ -244,7 +244,8 @@ definitions:
         type: string
         description: >
           Identifier to identify the shared resource at the provider side. This is
-          unique per provider and per share.
+          unique per provider such that if the same resource is shared twice,
+          this shareId will not be repeated.
         example: 7c084226-d9a1-11e6-bf26-cec0c932ce01
       owner:
         description: |
@@ -366,7 +367,7 @@ definitions:
         example: file
       shareId:
         type: string
-        description: ID of the shared resource on the provider side
+        description: ID of the shared resource on the provider side, formerly known as providerId
         example: 7c084226-d9a1-11e6-bf26-cec0c932ce01
       notification:
         type: object

--- a/spec.yaml
+++ b/spec.yaml
@@ -201,8 +201,9 @@ definitions:
     required:
       - shareWith
       - name
-      - providerId
+      - resourceId
       - owner
+      - sender
       - protocols
       - permission
       - shareType
@@ -226,9 +227,9 @@ definitions:
         example: >-
           This is the Open API Specification file (in YAML format) of the Open
           Cloud Mesh API.
-      providerId:
+      resourceId:
         type: string
-        description: >-
+        description: >
           Identifier to identify the resource at the provider side. This is
           unique per provider.
         example: 7c084226-d9a1-11e6-bf26-cec0c932ce01

--- a/spec.yaml
+++ b/spec.yaml
@@ -48,16 +48,7 @@ paths:
       responses:
         '201':
           description: >
-            Consumer successfully received the share. The response might contain
-            the display name of the recipient of the share for general
-            user experience improvement
-          schema:
-            type: object
-            properties:
-              recipientDisplayName:
-                type: string
-                description: display name of the recipient
-                example: John Doe
+            Consumer successfully received the share.
         '400':
           description: >
             Bad request due to invalid parameters, e.g. when `shareWith` is not
@@ -267,7 +258,7 @@ definitions:
       shareType:
         type: string
         description: |
-          Share type (user or group share)
+          Recipient share type (user or group)
         example: user
       resourceType:
         type: string
@@ -287,30 +278,38 @@ definitions:
             items:
               type: string
               description: >
-                The name of the protocol(s) which is/are used to establish
+                Name(s) of the protocol(s) which is/are used to establish
                 synchronisation. The supported protocols are:
                 `webdav`, to access the data
                 `webapp`, to access remote web applications
+                `datatx`, to transfer the data to the remote endpoint
                 Other custom protocols might be added in the future.
               enum:
                 - webdav
                 - webapp
+                - datatx
               example: webdav
           options:
             type: object
             description: >
-              JSON object with protocol specific options, e.g. `uri`,
+              JSON object with specific options for each protocol, e.g. `uri`,
               `access_token`, `password`, `permissions` etc.
               For backward compatibility, the webdav protocol will use
               `sharedSecret` as username and password.
-              The `webapp` protocol is expected to provide a (templated)
-              URI to a client-browsable view of the shared resource, with
-              all relevant applications enabled: implementations may
-              leverage the public link capability for this feature.
+              The `webapp` protocol is expected to provide a (templated) URI
+              to a client-browsable view of the shared resource, such that users
+              may use the web applications available at the site: implementations
+              may leverage the public link capability for this feature.
             example:
-              sharedSecret: "hfiuhworzwnur98d3wjiwhr"
-              permissions: "{https://open-cloud-mesh.org/ns}share-permissions"
-              uriTemplate: "https://open-cloud-mesh.org/s/{path-to-shared-resources}"
+              webdav:
+                sharedSecret: "hfiuhworzwnur98d3wjiwhr"
+                permissions: ["read", "write", "share"]
+                uri: "https://open-cloud-mesh.org/remote.php/webdav/path/to/resource"
+              webapp:
+                uriTemplate: "https://open-cloud-mesh.org/s/rglsertgsrt/{relative-path-to-shared-resource}"
+              datatx:
+                sharedSecret: "hfiuhworzwnur98d3wjiwhr"
+                srcUri: "https://open-cloud-mesh.org/remote.php/webdav/path/to/resource"
   NewNotification:
     type: object
     required:

--- a/spec.yaml
+++ b/spec.yaml
@@ -264,10 +264,9 @@ definitions:
         example: user
       resourceType:
         type: string
-        enum: ["file", "folder"]
         description: |
-          Resource type
-        example: file
+          Resource type (file, folder, calendar, contact, ...)
+        example: folder
       expiration:
         type: integer
         description: |

--- a/spec.yaml
+++ b/spec.yaml
@@ -214,8 +214,7 @@ definitions:
     required:
       - shareWith
       - name
-      - providerId
-      - resourceId
+      - shareId
       - owner
       - sender
       - protocols
@@ -241,17 +240,11 @@ definitions:
         example: >-
           This is the Open API Specification file (in YAML format) of the Open
           Cloud Mesh API.
-      resourceId:
+      shareId:
         type: string
         description: >
-          Identifier to identify the resource at the provider side. This is
-          unique per provider.
-        example: 7c084226-d9a1-11e6-bf26-cec0c932ce01
-      providerId:
-        type: string
-        description: >
-          Identifier to identify the resource at the provider side. This is
-          unique per provider (deprecated).
+          Identifier to identify the shared resource at the provider side. This is
+          unique per provider and per share.
         example: 7c084226-d9a1-11e6-bf26-cec0c932ce01
       owner:
         description: |
@@ -371,9 +364,9 @@ definitions:
         description: |
           A resource type (e.g. file, calendar, contact)
         example: file
-      providerId:
+      shareId:
         type: string
-        description: ID of the resource on the provider side
+        description: ID of the shared resource on the provider side
         example: 7c084226-d9a1-11e6-bf26-cec0c932ce01
       notification:
         type: object

--- a/spec.yaml
+++ b/spec.yaml
@@ -253,7 +253,7 @@ definitions:
       senderDisplayName:
         type: string
         description: |
-          Display name of the owner of the resource
+          Display name of the user that wants to share the resource
         example: John Doe
       shareType:
         type: string

--- a/spec.yaml
+++ b/spec.yaml
@@ -210,6 +210,7 @@ definitions:
     required:
       - shareWith
       - name
+      - providerId
       - resourceId
       - owner
       - sender

--- a/spec.yaml
+++ b/spec.yaml
@@ -309,6 +309,9 @@ definitions:
               properties:
                 uriTemplate:
                   type: string
+                viewMode:
+                  type: string
+                  enum: ["view", "read", "write"]
             datatx:
               type: object
               properties:
@@ -325,6 +328,7 @@ definitions:
             uri: "https://open-cloud-mesh.org/remote.php/webdav/path/to/resource"
           webapp:
             uriTemplate: "https://open-cloud-mesh.org/s/share-hash/{relative-path-to-shared-resource}"
+            viewMode: "write"
           datatx:
             sharedSecret: secret
             srcUri: "https://open-cloud-mesh.org/remote.php/webdav/path/to/resource"

--- a/spec.yaml
+++ b/spec.yaml
@@ -154,7 +154,7 @@ paths:
       description: >
         Inform about an accepted invitation so the user on the sender provider's side can initiate the OCM share creation.
         To protect the identity of the parties, for shares created following an OCM invitation,
-        the user id SHALL be hashed, and recipients implementing the OCM invitation workflow
+        the user id MAY be hashed, and recipients implementing the OCM invitation workflow
         MAY refuse to process shares coming from unknown parties.
       parameters:
         - name: invite

--- a/spec.yaml
+++ b/spec.yaml
@@ -265,52 +265,33 @@ definitions:
         description: |
           Resource type (file, calendar, contact, ...)
         example: file
-      protocol:
+      protocols:
         type: object
         description: >
-          The protocol(s) which is/are used to establish synchronisation.
-        required:
-          - name
-          - options
-        properties:
-          name:
-            type: array
-            items:
-              type: string
-              description: >
-                Name(s) of the protocol(s) which is/are used to establish
-                synchronisation. The supported protocols are:
-                `webdav`, to access the data
-                `webapp`, to access remote web applications
-                `datatx`, to transfer the data to the remote endpoint
-                Other custom protocols might be added in the future.
-              enum:
-                - webdav
-                - webapp
-                - datatx
-              example: webdav
-          options:
-            type: object
-            description: >
-              JSON object with specific options for each protocol, e.g. `uri`,
-              `access_token`, `password`, `permissions` etc.
-              For backward compatibility, the webdav protocol will use
-              `sharedSecret` as username and password.
-              The `webapp` protocol is expected to provide a (templated) URI
-              to a client-browsable view of the shared resource, such that users
-              may use the web applications available at the site: implementations
-              may leverage the public link capability for this feature.
-            example:
-              webdav:
-                sharedSecret: "hfiuhworzwnur98d3wjiwhr"
-                permissions: ["read", "write", "share"]
-                uri: "https://open-cloud-mesh.org/remote.php/webdav/path/to/resource"
-              webapp:
-                uriTemplate: "https://open-cloud-mesh.org/s/rglsertgsrt/{relative-path-to-shared-resource}"
-              datatx:
-                sharedSecret: "hfiuhworzwnur98d3wjiwhr"
-                srcUri: "https://open-cloud-mesh.org/remote.php/webdav/path/to/resource"
-                size: 1000000000000
+          JSON object with specific options for each protocol, e.g. `uri`,
+          `access_token`, `password`, `permissions` etc.
+          For backward compatibility, the webdav protocol will use
+          `sharedSecret` as username and password.
+          The `webapp` protocol is expected to provide a (templated) URI
+          to a client-browsable view of the shared resource, such that users
+          may use the web applications available at the site: implementations
+          may leverage the public link capability for this feature.
+          The supported protocols are:
+          `webdav`, to access the data
+          `webapp`, to access remote web applications
+          `datatx`, to transfer the data to the remote endpoint
+          Other custom protocols might be added in the future.
+        example:
+          webdav:
+            sharedSecret: "hfiuhworzwnur98d3wjiwhr"
+            permissions: ["read", "write", "share"]
+            uri: "https://open-cloud-mesh.org/remote.php/webdav/path/to/resource"
+          webapp:
+            uriTemplate: "https://open-cloud-mesh.org/s/rglsertgsrt/{relative-path-to-shared-resource}"
+          datatx:
+            sharedSecret: "hfiuhworzwnur98d3wjiwhr"
+            srcUri: "https://open-cloud-mesh.org/remote.php/webdav/path/to/resource"
+            size: 1000000000000
   NewNotification:
     type: object
     required:

--- a/spec.yaml
+++ b/spec.yaml
@@ -211,7 +211,6 @@ definitions:
       - shareWith
       - name
       - resourceId
-      - providerId
       - owner
       - sender
       - protocols

--- a/spec.yaml
+++ b/spec.yaml
@@ -287,6 +287,7 @@ definitions:
             permissions: ["read", "write", "share"]
             uri: "https://open-cloud-mesh.org/remote.php/webdav/path/to/resource"
           webapp:
+            sharedSecret: "hfiuhworzwnur98d3wjiwhr"
             uriTemplate: "https://open-cloud-mesh.org/s/rglsertgsrt/{relative-path-to-shared-resource}"
           datatx:
             sharedSecret: "hfiuhworzwnur98d3wjiwhr"

--- a/spec.yaml
+++ b/spec.yaml
@@ -1,4 +1,4 @@
-swagger: '2.0'
+swagger: "2.0"
 info:
   title: Open Cloud Mesh API
   description: Open Cloud Mesh Open API Specification.
@@ -44,32 +44,32 @@ paths:
           description: The JSON object to create a new share at the consumer side.
           required: true
           schema:
-            $ref: '#/definitions/NewShare'
+            $ref: "#/definitions/NewShare"
       responses:
-        '201':
+        "201":
           description: >
             Consumer successfully received the share.
-        '400':
+        "400":
           description: >
             Bad request due to invalid parameters, e.g. when `shareWith` is not
             found or required properties are missing.
           schema:
-            $ref: '#/definitions/400'
-        '401':
+            $ref: "#/definitions/400"
+        "401":
           description: Client cannot be authenticated as a trusted service.
           schema:
-            $ref: '#/definitions/Error'
-        '403':
+            $ref: "#/definitions/Error"
+        "403":
           description: Trusted service is not authorized to create shares.
           schema:
-            $ref: '#/definitions/Error'
-        '501':
+            $ref: "#/definitions/Error"
+        "501":
           description: >-
             The consumer doesn't support incoming external shares, the share
             type or the resource type is not supported.
           schema:
-            $ref: '#/definitions/Error'
-        '503':
+            $ref: "#/definitions/Error"
+        "503":
           description: >-
             The consumer is temporary unavailable (e.g. due to planned
             maintenance).
@@ -84,7 +84,7 @@ paths:
                 within 50 minutes).
               type: string
           schema:
-            $ref: '#/definitions/Error'
+            $ref: "#/definitions/Error"
   /notifications:
     post:
       summary: Send a notification to a trusted service
@@ -97,34 +97,34 @@ paths:
           description: The JSON object with a new notification
           required: true
           schema:
-            $ref: '#/definitions/NewNotification'
+            $ref: "#/definitions/NewNotification"
       responses:
-        '201':
+        "201":
           description: >
             Receiver succesfully received the notification. The response body
             can contain a JSON object with some resonse data, depending on the
             specification of the actual notification.
-        '400':
+        "400":
           description: >
             Bad request due to invalid parameters, e.g. when `type` is invalid
             or missing.
           schema:
-            $ref: '#/definitions/400'
-        '401':
+            $ref: "#/definitions/400"
+        "401":
           description: Client cannot be authenticated as a trusted service.
           schema:
-            $ref: '#/definitions/Error'
-        '403':
+            $ref: "#/definitions/Error"
+        "403":
           description: Trusted service is not authorized to create notifications.
           schema:
-            $ref: '#/definitions/Error'
-        '501':
+            $ref: "#/definitions/Error"
+        "501":
           description: >-
             The receiver doesn't support notifications, the resource type is not
             supported.
           schema:
-            $ref: '#/definitions/Error'
-        '503':
+            $ref: "#/definitions/Error"
+        "503":
           description: >-
             The receiver is temporary unavailable (e.g. due to planned
             maintenance).
@@ -138,7 +138,7 @@ paths:
                 available again within 50 minutes).
               type: string
           schema:
-            $ref: '#/definitions/Error'
+            $ref: "#/definitions/Error"
   /invite-accepted:
     post:
       summary: Inform the sender that the invitation was accepted to start sharing.
@@ -158,16 +158,16 @@ paths:
         400:
           description: The invitation token is invalid.
           schema:
-            $ref: "#/definitions/Error" 
+            $ref: "#/definitions/Error"
         403:
           description: Remote service is not trusted to accept invitations.
           schema:
             $ref: "#/definitions/Error"
 definitions:
-  '400':
+  "400":
     type: object
     allOf:
-      - $ref: '#/definitions/Error'
+      - $ref: "#/definitions/Error"
       - properties:
           validationErrors:
             type: array
@@ -310,6 +310,7 @@ definitions:
               datatx:
                 sharedSecret: "hfiuhworzwnur98d3wjiwhr"
                 srcUri: "https://open-cloud-mesh.org/remote.php/webdav/path/to/resource"
+                size: 1000000000000
   NewNotification:
     type: object
     required:
@@ -345,7 +346,7 @@ definitions:
     allOf:
       - properties:
           recipientProvider:
-            type: string 
+            type: string
             format: url
             description: URL of the receiver OCM service.
             example: https://receiver.org

--- a/spec.yaml
+++ b/spec.yaml
@@ -268,6 +268,11 @@ definitions:
         description: |
           Resource type
         example: file
+      expiration:
+        type: integer
+        description: |
+          The expiration time for the ocm share.
+          Represents seconds of UTC time since Unix epoch.
       protocols:
         type: object
         description: >

--- a/spec.yaml
+++ b/spec.yaml
@@ -203,7 +203,7 @@ definitions:
       - name
       - providerId
       - owner
-      - protocol
+      - protocols
       - permission
       - shareType
       - resourceType

--- a/spec.yaml
+++ b/spec.yaml
@@ -257,13 +257,15 @@ definitions:
         example: John Doe
       shareType:
         type: string
+        enum: ["user", "group"]
         description: |
-          Recipient share type (user or group)
+          Recipient share type
         example: user
       resourceType:
         type: string
+        enum: ["file", "folder"]
         description: |
-          Resource type (file, calendar, contact, ...)
+          Resource type
         example: file
       protocols:
         type: object
@@ -281,16 +283,44 @@ definitions:
           `webapp`, to access remote web applications
           `datatx`, to transfer the data to the remote endpoint
           Other custom protocols might be added in the future.
+        additionalProperties:
+          type: object
+          properties:
+            webdav:
+              type: object
+              properties:
+                sharedSecret:
+                  type: string
+                permissions:
+                  type: array
+                  items:
+                    type: string
+                    enum: ["read", "write", "share"]
+                uri:
+                  type: string
+            webapp:
+              type: object
+              properties:
+                uriTemplate:
+                  type: string
+            datatx:
+              type: object
+              properties:
+                sharedSecret:
+                  type: string
+                srcUri:
+                  type: string
+                size:
+                  type: integer
         example:
           webdav:
-            sharedSecret: "secret"
-            permissions: ["read", "write", "share"]
+            sharedSecret: secret
+            permissions: ["read"]
             uri: "https://open-cloud-mesh.org/remote.php/webdav/path/to/resource"
           webapp:
-            sharedSecret: "secret"
-            uriTemplate: "https://open-cloud-mesh.org/s/{share-id}/{relative-path-to-shared-resource}"
+            uriTemplate: "https://open-cloud-mesh.org/s/share-hash/{relative-path-to-shared-resource}"
           datatx:
-            sharedSecret: "secret"
+            sharedSecret: secret
             srcUri: "https://open-cloud-mesh.org/remote.php/webdav/path/to/resource"
             size: 1000000000000
   NewNotification:


### PR DESCRIPTION
Closes https://github.com/cs3org/OCM-API/issues/56

 Co-authored with @glpatcern

Includes:
* Properties of the `protocols` parameter in `NewShare` fully spelled out [this is a breaking change].
* Renamed `providerId` as `shareId`, both in `NewShare` and in `/notifications`, as this is how it is meant to be [this is a breaking change, though semantic is unchanged].
 
The corresponding changes in the CS3 APIs are in https://github.com/cs3org/cs3apis/pull/199