### PR TITLE
Add more errors on invite-accepted endpoint

### DIFF
--- a/spec.yaml
+++ b/spec.yaml
@@ -167,11 +167,20 @@ paths:
         400:
           description: The invitation token is invalid.
           schema:
-            $ref: "#/definitions/Error" 
+            $ref: "#/definitions/Error"
         403:
           description: Remote service is not trusted to accept invitations.
           schema:
             $ref: "#/definitions/Error"
+        404:
+          description: The invitation token does not exist.
+          schema:
+            $ref: "#/definitions/Error"
+        409:
+          description: User is already known by the OCM provider.
+          schema:
+            $ref: "#/definitions/Error"
+
 definitions:
   '400':
     type: object


### PR DESCRIPTION
This PR adds two more errors to the `/invite-accepted` endpoint:
  - when the user is already known by the ocm provider
  - the token does not exist