### PR TITLE
Add discovery endpoint

### DIFF
--- a/spec.yaml
+++ b/spec.yaml
@@ -309,16 +309,16 @@ definitions:
                         are expected to execute the transfer using WebDAV as
                         the wire protocol.
                       example: https://my-cloud-storage.org/remote.php/dav/ocm
-          capabilities:
-            type: array
-            description: |
-              The capabilities exposed at this endpoint according to the present
-              specifications. Implementations MUST expose `/shares` at a minimum.
-            items:
-              type: string
-              enum: ["/shares", "/notifications", "/invite-accepted"]
-            example:
-              ["/shares", "/invite-accepted"]
+      capabilities:
+        type: array
+        description: |
+          The capabilities exposed at this endpoint according to the present
+          specifications. Implementations MUST expose `/shares` at a minimum.
+        items:
+          type: string
+          enum: ["/shares", "/notifications", "/invite-accepted"]
+        example:
+          ["/shares", "/invite-accepted"]
   NewShare:
     type: object
     required:

--- a/spec.yaml
+++ b/spec.yaml
@@ -292,8 +292,8 @@ definitions:
                     a remote shared resource, implementations MAY use this
                     URI as a prefix: e.g. if in a new share request's payload
                     a `protocol.options.sharedSecret` property is defined
-                    (see singleProtocolLegacy example), it may need to be
-                    appended to this URI to access the resource.
+                    (see singleProtocolLegacy example), implementations MAY
+                    need to append it to this URI to access the resource.
                   example: https://my-cloud-storage.org/remote.php/dav/ocm
                 webapp:
                   type: string
@@ -314,7 +314,7 @@ definitions:
       capabilities:
         type: array
         description: |
-          The capabilities exposed at this endpoint according to the present
+          The optional capabilities exposed at this endpoint according to the present
           specifications. As implementations MUST provide `/shares` to be compliant,
           it is not necessary to expose it as a capability.
         items:

--- a/spec.yaml
+++ b/spec.yaml
@@ -245,7 +245,7 @@ definitions:
       apiVersion:
         type: string
         description: The OCM API version this endpoint supports
-        example: 1.0-proposal1
+        example: 1.0.0
       endPoint:
         type: string
         description: The URI of the OCM API available at this endpoint
@@ -288,8 +288,9 @@ definitions:
                         The top-level WebDAV endpoint URI. In order to access a
                         remote shared resource, implementations MAY use this
                         URI as a prefix: e.g. if in a new share request's payload
-                        a `protocol.options.sharedSecret` property is defined,
-                        it should be appended to this URI to access the resource.
+                        a `protocol.options.sharedSecret` property is defined
+                        (see singleProtocolLegacy example), it may need to be
+                        appended to this URI to access the resource.
                       example: https://my-cloud-storage.org/remote.php/dav/ocm
                 - properties:
                     webapp:

--- a/spec.yaml
+++ b/spec.yaml
@@ -41,6 +41,7 @@ paths:
         for more details).
       responses:
         "200":
+          description: The capabilities of this OCM service
           schema:
             $ref: "#/definitions/Discovery"
   /shares:

--- a/spec.yaml
+++ b/spec.yaml
@@ -284,17 +284,30 @@ definitions:
                 - properties:
                     webdav:
                       type: string
-                      description: The top-level WebDAV endpoint
+                      description: |
+                        The top-level WebDAV endpoint URI. In order to access a
+                        remote shared resource, implementations MAY use this
+                        URI as a prefix: e.g. if in a new share request's payload
+                        a `protocol.options.sharedSecret` property is defined,
+                        it should be appended to this URI to access the resource.
                       example: https://my-cloud-storage.org/remote.php/dav/ocm
                 - properties:
                     webapp:
                       type: string
-                      description: The top-level endpoint for web apps
+                      description: |
+                        The top-level endpoint URI for web apps. This value is
+                        provided for documentation purposes, and it SHALL NOT
+                        be intended as a prefix for share requests.
                       example: https://my-cloud-storage.org/external/ocm
                 - properties:
                     datatx:
                       type: string
-                      description: The top-level endpoint for data transfers
+                      description: |
+                        The top-level endpoint URI for data transfers. This value
+                        is provided for documentation purposes, and it SHALL NOT
+                        be intended as a prefix. Furthermore, implementations
+                        are expected to execute the transfer using WebDAV as
+                        the wire protocol.
                       example: https://my-cloud-storage.org/remote.php/dav/ocm
           capabilities:
             type: array

--- a/spec.yaml
+++ b/spec.yaml
@@ -2,7 +2,7 @@ swagger: "2.0"
 info:
   title: Open Cloud Mesh API
   description: Open Cloud Mesh Open API Specification.
-  version: 2.0.0
+  version: 1.0.0
   x-logo:
     url: logo.png
 schemes:
@@ -245,7 +245,7 @@ definitions:
       apiVersion:
         type: string
         description: The OCM API version this endpoint supports
-        example: 2.0.0
+        example: 1.0-proposal1
       endPoint:
         type: string
         description: The URI of the OCM API available at this endpoint

--- a/spec.yaml
+++ b/spec.yaml
@@ -257,7 +257,10 @@ definitions:
         example: MyCloudStorage
       resourceTypes:
         type: array
-        description: A list of all supported resource types with their access protocols
+        description: |
+          A list of all supported resource types with their access protocols.
+          Each resource type is identified by its `name`: the list MUST NOT
+          contain more than one resource type object per given `name`.
         items:
           type: object
           properties:

--- a/spec.yaml
+++ b/spec.yaml
@@ -281,36 +281,33 @@ definitions:
               description: |
                 The supported protocols to access shares at this endpoint.
                 Implementations MUST support `webdav` at a minimum.
-              anyOf:
-                - properties:
-                    webdav:
-                      type: string
-                      description: |
-                        The top-level WebDAV endpoint full URI. In order to access
-                        a remote shared resource, implementations MAY use this
-                        URI as a prefix: e.g. if in a new share request's payload
-                        a `protocol.options.sharedSecret` property is defined
-                        (see singleProtocolLegacy example), it may need to be
-                        appended to this URI to access the resource.
-                      example: https://my-cloud-storage.org/remote.php/dav/ocm
-                - properties:
-                    webapp:
-                      type: string
-                      description: |
-                        The top-level endpoint full URI for web apps. This value
-                        is provided for documentation purposes, and it SHALL NOT
-                        be intended as a prefix for share requests.
-                      example: https://my-cloud-storage.org/external/ocm
-                - properties:
-                    datatx:
-                      type: string
-                      description: |
-                        The top-level endpoint full URI for data transfers. This
-                        value is provided for documentation purposes, and it SHALL
-                        NOT be intended as a prefix. Furthermore, implementations
-                        are expected to execute the transfer using WebDAV as
-                        the wire protocol.
-                      example: https://my-cloud-storage.org/remote.php/dav/ocm
+              properties:
+                webdav:
+                  type: string
+                  description: |
+                    The top-level WebDAV endpoint full URI. In order to access
+                    a remote shared resource, implementations MAY use this
+                    URI as a prefix: e.g. if in a new share request's payload
+                    a `protocol.options.sharedSecret` property is defined
+                    (see singleProtocolLegacy example), it may need to be
+                    appended to this URI to access the resource.
+                  example: https://my-cloud-storage.org/remote.php/dav/ocm
+                webapp:
+                  type: string
+                  description: |
+                    The top-level endpoint full URI for web apps. This value
+                    is provided for documentation purposes, and it SHALL NOT
+                    be intended as a prefix for share requests.
+                  example: https://my-cloud-storage.org/external/ocm
+                datatx:
+                  type: string
+                  description: |
+                    The top-level endpoint full URI for data transfers. This
+                    value is provided for documentation purposes, and it SHALL
+                    NOT be intended as a prefix. In addition, implementations
+                    are expected to execute the transfer using WebDAV as
+                    the wire protocol.
+                  example: https://my-cloud-storage.org/remote.php/dav/ocm
       capabilities:
         type: array
         description: |

--- a/spec.yaml
+++ b/spec.yaml
@@ -296,6 +296,16 @@ definitions:
                       type: string
                       description: The top-level endpoint for data transfers
                       example: https://my-cloud-storage.org/remote.php/dav/ocm
+          capabilities:
+            type: array
+            description: |
+              The capabilities exposed at this endpoint according to the present
+              specifications. Implementations MUST expose `/shares` at a minimum.
+            items:
+              type: string
+              enum: ["/shares", "/notifications", "/invite-accepted"]
+            example:
+              ["/shares", "/invite-accepted"]
   NewShare:
     type: object
     required:

--- a/spec.yaml
+++ b/spec.yaml
@@ -263,34 +263,39 @@ definitions:
             name:
               type: string
               description: |
-                A supported resource type (file, folder, calendar, contact, ...)
+                A supported resource type (file, folder, calendar, contact, ...).
+                Implementations MUST support `file` at a minimum.
               example: file
             shareTypes:
               type: array
-              description: The supported recipient share types
+              description: |
+                The supported recipient share types.
+                Implementations MUST support `user` at a minimum.
               items:
                 type: string
                 enum: ["user", "group", "federation"]
+              example: ["user"]
             protocols:
               type: object
               description: |
-                The supported protocols to access shares at this endpoint
+                The supported protocols to access shares at this endpoint.
+                Implementations MUST support `webdav` at a minimum.
               anyOf:
                 - properties:
                     webdav:
                       type: string
                       description: The top-level WebDAV endpoint
-                      example: https://my-cloud-storage.org/ocm
+                      example: https://my-cloud-storage.org/remote.php/dav/ocm
                 - properties:
                     webapp:
                       type: string
                       description: The top-level endpoint for web apps
-                      example: https://my-cloud-storage.org
+                      example: https://my-cloud-storage.org/external/ocm
                 - properties:
                     datatx:
                       type: string
                       description: The top-level endpoint for data transfers
-                      example: https://my-cloud-storage.org
+                      example: https://my-cloud-storage.org/remote.php/dav/ocm
   NewShare:
     type: object
     required:

--- a/spec.yaml
+++ b/spec.yaml
@@ -2,7 +2,7 @@ swagger: "2.0"
 info:
   title: Open Cloud Mesh API
   description: Open Cloud Mesh Open API Specification.
-  version: 1.0.0
+  version: 2.0.0
   x-logo:
     url: logo.png
 schemes:
@@ -30,6 +30,19 @@ parameters:
       the HAL navigation links (e.g. `_links.next.href`) to paginate. These
       links enable the possibility to use vendor specific pagination.
 paths:
+  /ocm-provider:
+    get:
+      summary: Discovery endpoint
+      description: >
+        This endpoint returns a number of properties used to discover the capabilities
+        offered by a remote cloud storage. The endpoint is named `/ocm-provider` owing
+        to already established practices and constraints with the main cloud storages
+        that implement OCM (see https://github.com/cs3org/OCM-API/pull/37#issuecomment-435875108
+        for more details).
+      responses:
+        "200":
+          schema:
+            $ref: "#/definitions/Discovery"
   /shares:
     post:
       summary: Create a new share
@@ -218,6 +231,66 @@ definitions:
           (e.g. no use of special characters) providing more information
           on the cause of the error.
         example: RESOURCE_NOT_FOUND
+  Discovery:
+    type: object
+    required:
+      - enabled
+      - apiVersion
+      - endPoint
+      - resourceTypes
+    properties:
+      enabled:
+        type: boolean
+        description: Whether the OCM service is enabled at this endpoint
+      apiVersion:
+        type: string
+        description: The OCM API version this endpoint supports
+        example: 2.0.0
+      endPoint:
+        type: string
+        description: The URI of the OCM API available at this endpoint
+        example: https://my-cloud-storage.org/ocm
+      provider:
+        type: string
+        description: A friendly branding name of this endpoint
+        example: MyCloudStorage
+      resourceTypes:
+        type: array
+        description: A list of all supported resource types with their access protocols
+        items:
+          type: object
+          properties:
+            name:
+              type: string
+              description: |
+                A supported resource type (file, folder, calendar, contact, ...)
+              example: file
+            shareTypes:
+              type: array
+              description: The supported recipient share types
+              items:
+                type: string
+                enum: ["user", "group", "federation"]
+            protocols:
+              type: object
+              description: |
+                The supported protocols to access shares at this endpoint
+              anyOf:
+                - properties:
+                    webdav:
+                      type: string
+                      description: The top-level WebDAV endpoint
+                      example: https://my-cloud-storage.org/ocm
+                - properties:
+                    webapp:
+                      type: string
+                      description: The top-level endpoint for web apps
+                      example: https://my-cloud-storage.org
+                - properties:
+                    datatx:
+                      type: string
+                      description: The top-level endpoint for data transfers
+                      example: https://my-cloud-storage.org
   NewShare:
     type: object
     required:

--- a/spec.yaml
+++ b/spec.yaml
@@ -285,8 +285,8 @@ definitions:
                     webdav:
                       type: string
                       description: |
-                        The top-level WebDAV endpoint URI. In order to access a
-                        remote shared resource, implementations MAY use this
+                        The top-level WebDAV endpoint full URI. In order to access
+                        a remote shared resource, implementations MAY use this
                         URI as a prefix: e.g. if in a new share request's payload
                         a `protocol.options.sharedSecret` property is defined
                         (see singleProtocolLegacy example), it may need to be
@@ -296,17 +296,17 @@ definitions:
                     webapp:
                       type: string
                       description: |
-                        The top-level endpoint URI for web apps. This value is
-                        provided for documentation purposes, and it SHALL NOT
+                        The top-level endpoint full URI for web apps. This value
+                        is provided for documentation purposes, and it SHALL NOT
                         be intended as a prefix for share requests.
                       example: https://my-cloud-storage.org/external/ocm
                 - properties:
                     datatx:
                       type: string
                       description: |
-                        The top-level endpoint URI for data transfers. This value
-                        is provided for documentation purposes, and it SHALL NOT
-                        be intended as a prefix. Furthermore, implementations
+                        The top-level endpoint full URI for data transfers. This
+                        value is provided for documentation purposes, and it SHALL
+                        NOT be intended as a prefix. Furthermore, implementations
                         are expected to execute the transfer using WebDAV as
                         the wire protocol.
                       example: https://my-cloud-storage.org/remote.php/dav/ocm
@@ -314,12 +314,13 @@ definitions:
         type: array
         description: |
           The capabilities exposed at this endpoint according to the present
-          specifications. Implementations MUST expose `/shares` at a minimum.
+          specifications. As implementations MUST provide `/shares` to be compliant,
+          it is not necessary to expose it as a capability.
         items:
           type: string
-          enum: ["/shares", "/notifications", "/invite-accepted"]
+          enum: ["/notifications", "/invite-accepted"]
         example:
-          ["/shares", "/invite-accepted"]
+          ["/invite-accepted"]
   NewShare:
     type: object
     required:


### PR DESCRIPTION
This PR adds the `/ocm-provider` discovery endpoint, modeled after the already existing implementations.

Also, the OCM API version is pushed to `2.0.0`, given the current state of the `develop` branch. The goal is to agree on an official v2 release of the protocol at the CS3 event in Barcelona (see www.cs3community.org).

Edit: we agreed we would have a dedicated OCM-related meeting, where this and other outstanding items are to be discussed. Out of that meeting (cf. also #69), this PR specifies the behavior of the current implementations, including the exposed version, and adds an optional `capabilities` property.

In a future PR, we will push the version to `1.1.0`.

Closes https://github.com/cs3org/OCM-API/issues/51
