### PR TITLE
Renamed/reintroduced properties to ease backwards compatibility

### DIFF
--- a/spec.yaml
+++ b/spec.yaml
@@ -452,7 +452,9 @@ definitions:
                   description: |
                     An URI to access the remote resource. The URI MAY be relative,
                     in which case the prefix exposed by the `/ocm-provider` endpoint MUST
-                    be used, or it may be absolute (recommended).
+                    be used, or it may be absolute (recommended). Additionally, the URI
+                    MAY include a secret hash in the path, in which case there MAY be
+                    no associated `sharedSecret`.
             webapp:
               type: object
               properties:
@@ -460,7 +462,10 @@ definitions:
                   type: string
                   description: |
                     A templated URI to a client-browsable view of the shared resource,
-                    such that users may use the web applications available at the site
+                    such that users may use the web applications available at the site.
+                    The URI MAY include a secret hash in the path. If the path includes
+                    a `{relative-path-to-shared-resource}` placeholder, implementations
+                    MAY replace it with the actual path to ease user interaction.
                 viewMode:
                   type: string
                   description: |
@@ -487,7 +492,8 @@ definitions:
                   description: |
                     An URI to access the remote resource. The URI MAY be relative,
                     in which case the prefix exposed by the `/ocm-provider` endpoint MUST
-                    be used, or it may be absolute (recommended).
+                    be used, or it may be absolute (recommended). Additionally, the
+                    URI MAY include a secret hash in the path.
                 size:
                   type: integer
         example:
@@ -499,9 +505,8 @@ definitions:
           singleProtocolNew:
             name: "multi"
             webdav:
-              sharedSecret: "hfiuhworzwnur98d3wjiwhr"
               permissions: ["read"]
-              uri: "https://open-cloud-mesh.org/remote.php/webdav/path/to/spec.yaml"
+              uri: "https://open-cloud-mesh.org/remote.php/webdav/share-hash/path/to/spec.yaml"
           multipleProtocols:
             name: "multi"
             options:

--- a/spec.yaml
+++ b/spec.yaml
@@ -337,7 +337,7 @@ definitions:
     properties:
       shareWith:
         type: string
-        description: >
+        description: |
           Consumer specific identifier of the user, group or federation the provider
           wants to share the resource with. This is known in advance.
           Please note that the consumer service endpoint is known in advance
@@ -350,12 +350,12 @@ definitions:
       description:
         type: string
         description: Optional description of the resource (file or folder).
-        example: >-
+        example: |
           This is the Open API Specification file (in YAML format) of the Open
           Cloud Mesh API.
       providerId:
         type: string
-        description: >
+        description: |
           Identifier to identify the shared resource at the provider side. This is
           unique per provider such that if the same resource is shared twice,
           this providerId will not be repeated.
@@ -366,7 +366,7 @@ definitions:
         type: string
         example: 6358b71804dfa8ab069cf05ed1b0ed2a@apiwise.nl
       sender:
-        description: >
+        description: |
           Provider specific identifier of the user that wants to share the
           resource. Please note that the requesting provider is being
           identified on a higher level, so the former `remote` property
@@ -393,45 +393,38 @@ definitions:
         type: string
         description: |
           Resource type (file, folder, calendar, contact, ...)
-        example: folder
+        example: file
       expiration:
         type: integer
         description: |
-          The expiration time for the ocm share.
+          The expiration time for the OCM share.
           Represents seconds of UTC time since Unix epoch.
       protocol:
         type: object
-        description: >
-          JSON object with specific options for each protocol, e.g. `uri`,
-          `access_token`, `password`, `permissions` etc.
-          For backward compatibility, the webdav protocol will use
-          `sharedSecret` as username and password.
-          The `webapp` protocol is expected to provide a (templated) URI
-          to a client-browsable view of the shared resource, such that users
-          may use the web applications available at the site: implementations
-          may leverage the public link capability for this feature.
+        description: |
+          JSON object with specific options for each protocol.
           The supported protocols are:
-          `webdav`, to access the data
-          `webapp`, to access remote web applications
-          `datatx`, to transfer the data to the remote endpoint
+          - `webdav`, to access the data
+          - `webapp`, to access remote web applications
+          - `datatx`, to transfer the data to the remote endpoint
           Other custom protocols might be added in the future.
         required:
           - name
         name:
           type: string
           description: |
-            The name of the protocol. If `multi` is given, multiple protocol
+            The name of the protocol. If `multi` is given, one or more protocol
             endpoints are expected to be defined according to the optional
             properties specified below.
             Otherwise, at least `webdav` is expected to be supported,
-            and its options may be given either via those optional properties
-            (preferred), or as an opaque `options` payload.
+            and its options MAY be given in the opaque `options` payload
+            for backwards compatibility with v1.0 implementations.
         options:
           type: object
           description: |
             This property is now deprecated. Implementations are encouraged to
             transition to the new optional properties defined below, such that
-            this field can be removed in a future version of the spec.
+            this field may be removed in a future major version of the spec.
         additionalProperties:
           type: object
           properties:
@@ -440,28 +433,60 @@ definitions:
               properties:
                 sharedSecret:
                   type: string
+                  description: |
+                    An optional secret to be used to access the resource,
+                    such as a bearer token.
                 permissions:
                   type: array
                   items:
                     type: string
+                    description: |
+                      The permissions granted to the sharee.
+                      - `read` allows read-only access including download of a copy.
+                      - `write` allows create, update, and delete rights on the resource.
+                      - `share` allows re-share rights on the resource.
                     enum: ["read", "write", "share"]
                 uri:
                   type: string
+                  description: |
+                    An URI to access the remote resource. The URI MAY be relative,
+                    in which case the prefix exposed by the `/ocm-provider` endpoint MUST
+                    be used, or it may be absolute (recommended).
             webapp:
               type: object
               properties:
                 uriTemplate:
                   type: string
+                  description: |
+                    A templated URI to a client-browsable view of the shared resource,
+                    such that users may use the web applications available at the site
                 viewMode:
                   type: string
+                  description: |
+                    The permissions granted to the sharee.
+                    - `view` allows access to the web app in view-only mode.
+                    - `read` allows read and download access via the web app.
+                    - `write` allows full editing rights via the web app.
                   enum: ["view", "read", "write"]
+                sharedSecret:
+                  type: string
+                  description: |
+                    An optional secret to be used to access the remote web app,
+                    for example in the form of a bearer token.
             datatx:
               type: object
               properties:
                 sharedSecret:
                   type: string
+                  description: |
+                    An optional secret to be used to access the resource,
+                    for example in the form of a bearer token.
                 srcUri:
                   type: string
+                  description: |
+                    An URI to access the remote resource. The URI MAY be relative,
+                    in which case the prefix exposed by the `/ocm-provider` endpoint MUST
+                    be used, or it may be absolute (recommended).
                 size:
                   type: integer
         example:
@@ -470,14 +495,14 @@ definitions:
           webdav:
             sharedSecret: secret
             permissions: ["read"]
-            uri: "https://open-cloud-mesh.org/remote.php/webdav/path/to/resource"
+            uri: "https://open-cloud-mesh.org/remote.php/webdav/path/to/spec.yaml"
           webapp:
             uriTemplate: "https://open-cloud-mesh.org/s/share-hash/{relative-path-to-shared-resource}"
             viewMode: "write"
           datatx:
             sharedSecret: secret
-            srcUri: "https://open-cloud-mesh.org/remote.php/webdav/path/to/resource"
-            size: 1000000000000
+            srcUri: "https://open-cloud-mesh.org/remote.php/webdav/path/to/spec.yaml"
+            size: 100000
   NewNotification:
     type: object
     required:

--- a/spec.yaml
+++ b/spec.yaml
@@ -407,27 +407,28 @@ definitions:
           - `webdav`, to access the data
           - `webapp`, to access remote web applications
           - `datatx`, to transfer the data to the remote endpoint
+
           Other custom protocols might be added in the future.
-        required:
-          - name
-        name:
-          type: string
-          description: |
-            The name of the protocol. If `multi` is given, one or more protocol
-            endpoints are expected to be defined according to the optional
-            properties specified below.
-            Otherwise, at least `webdav` is expected to be supported,
-            and its options MAY be given in the opaque `options` payload
-            for backwards compatibility with v1.0 implementations.
-        options:
-          type: object
-          description: |
-            This property is now deprecated. Implementations are encouraged to
-            transition to the new optional properties defined below, such that
-            this field may be removed in a future major version of the spec.
         additionalProperties:
           type: object
+          required:
+            - name
           properties:
+            name:
+              type: string
+              description: |
+                The name of the protocol. If `multi` is given, one or more protocol
+                endpoints are expected to be defined according to the optional
+                properties specified below.
+                Otherwise, at least `webdav` is expected to be supported,
+                and its options MAY be given in the opaque `options` payload
+                for backwards compatibility with v1.0 implementations.
+            options:
+              type: object
+              description: |
+                This property is now deprecated. Implementations are encouraged to
+                transition to the new optional properties defined below, such that
+                this field may be removed in a future major version of the spec.
             webdav:
               type: object
               properties:

--- a/spec.yaml
+++ b/spec.yaml
@@ -164,7 +164,7 @@ paths:
             $ref: "#/definitions/Error"
   /invite-accepted:
     post:
-      summary: Inform the sender that the invitation was accepted to start sharing.
+      summary: Inform the sender that an invitation was accepted to start sharing.
       description: >
         Inform about an accepted invitation so the user on the sender provider's side can initiate the OCM share creation.
         To protect the identity of the parties, for shares created following an OCM invitation,

--- a/spec.yaml
+++ b/spec.yaml
@@ -327,10 +327,10 @@ definitions:
     required:
       - shareWith
       - name
-      - shareId
+      - providerId
       - owner
       - sender
-      - protocols
+      - protocol
       - permission
       - shareType
       - resourceType
@@ -353,12 +353,12 @@ definitions:
         example: >-
           This is the Open API Specification file (in YAML format) of the Open
           Cloud Mesh API.
-      shareId:
+      providerId:
         type: string
         description: >
           Identifier to identify the shared resource at the provider side. This is
           unique per provider such that if the same resource is shared twice,
-          this shareId will not be repeated.
+          this providerId will not be repeated.
         example: 7c084226-d9a1-11e6-bf26-cec0c932ce01
       owner:
         description: |
@@ -399,7 +399,7 @@ definitions:
         description: |
           The expiration time for the ocm share.
           Represents seconds of UTC time since Unix epoch.
-      protocols:
+      protocol:
         type: object
         description: >
           JSON object with specific options for each protocol, e.g. `uri`,
@@ -415,6 +415,23 @@ definitions:
           `webapp`, to access remote web applications
           `datatx`, to transfer the data to the remote endpoint
           Other custom protocols might be added in the future.
+        required:
+          - name
+        name:
+          type: string
+          description: |
+            The name of the protocol. If `multi` is given, multiple protocol
+            endpoints are expected to be defined according to the optional
+            properties specified below.
+            Otherwise, at least `webdav` is expected to be supported,
+            and its options may be given either via those optional properties
+            (preferred), or as an opaque `options` payload.
+        options:
+          type: object
+          description: |
+            This property is now deprecated. Implementations are encouraged to
+            transition to the new optional properties defined below, such that
+            this field can be removed in a future version of the spec.
         additionalProperties:
           type: object
           properties:
@@ -448,6 +465,8 @@ definitions:
                 size:
                   type: integer
         example:
+          name: 'multi'
+          options:
           webdav:
             sharedSecret: secret
             permissions: ["read"]
@@ -478,9 +497,9 @@ definitions:
         description: |
           A resource type (e.g. file, calendar, contact)
         example: file
-      shareId:
+      providerId:
         type: string
-        description: ID of the shared resource on the provider side, formerly known as providerId
+        description: ID of the shared resource on the provider side
         example: 7c084226-d9a1-11e6-bf26-cec0c932ce01
       notification:
         type: object

--- a/spec.yaml
+++ b/spec.yaml
@@ -420,9 +420,9 @@ definitions:
                 The name of the protocol. If `multi` is given, one or more protocol
                 endpoints are expected to be defined according to the optional
                 properties specified below.
-                Otherwise, at least `webdav` is expected to be supported,
-                and its options MAY be given in the opaque `options` payload
-                for backwards compatibility with v1.0 implementations.
+                Otherwise, at least `webdav` is expected to be supported, and
+                its options MAY be given in the opaque `options` payload for
+                compatibility with v1.0 implementations (see examples).
             options:
               type: object
               description: |
@@ -491,19 +491,31 @@ definitions:
                 size:
                   type: integer
         example:
-          name: 'multi'
-          options:
-          webdav:
-            sharedSecret: secret
-            permissions: ["read"]
-            uri: "https://open-cloud-mesh.org/remote.php/webdav/path/to/spec.yaml"
-          webapp:
-            uriTemplate: "https://open-cloud-mesh.org/s/share-hash/{relative-path-to-shared-resource}"
-            viewMode: "write"
-          datatx:
-            sharedSecret: secret
-            srcUri: "https://open-cloud-mesh.org/remote.php/webdav/path/to/spec.yaml"
-            size: 100000
+          singleProtocolLegacy:
+            name: "webdav"
+            options:
+              sharedSecret: "hfiuhworzwnur98d3wjiwhr"
+              permissions: "some permissions scheme"
+          singleProtocolNew:
+            name: "multi"
+            webdav:
+              sharedSecret: "hfiuhworzwnur98d3wjiwhr"
+              permissions: ["read"]
+              uri: "https://open-cloud-mesh.org/remote.php/webdav/path/to/spec.yaml"
+          multipleProtocols:
+            name: "multi"
+            options:
+            webdav:
+              sharedSecret: "hfiuhworzwnur98d3wjiwhr"
+              permissions: ["read"]
+              uri: "https://open-cloud-mesh.org/remote.php/webdav/path/to/spec.yaml"
+            webapp:
+              uriTemplate: "https://open-cloud-mesh.org/s/share-hash/{relative-path-to-shared-resource}"
+              viewMode: "read"
+            datatx:
+              sharedSecret: "hfiuhworzwnur98d3wjiwhr"
+              srcUri: "https://open-cloud-mesh.org/remote.php/webdav/path/to/spec.yaml"
+              size: 100000
   NewNotification:
     type: object
     required:


### PR DESCRIPTION
This closes #66 and #68, ~~to be discussed~~ according to the discussion we had today 29/03/2023.

In particular:
* The spec is backwards compatible, and descriptions were added to clarify how to use the additional properties vs the legacy ones.
* In `/shares`, the `protocol.name` serves as switch between legacy and new format, and the `protocol.options` field has been marked as deprecated, in favor of `protocol.webdav` and similar fields as already defined.
* In the new protocol properties, the permissions are now fully spelled out, as opposed to relying on an external permissions namespace.

https://cs3org.github.io/OCM-API/docs.html?branch=reconcile&repo=OCM-API&user=glpatcern for a rendered preview.