### PR TITLE
Prepare v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [1.2.0] - 2024-07-18 - Giuseppe Lo Presti <lopresti@cern.ch>
+
+* Added a `/.well-known` endpoint for discovery, to replace
+  the legacy `/ocm-provider` endpoint in a future release.
+* Added support for Multi-Factor Authentication.
+* Clarified access methods to remote shares: bearer token
+  authorization is the preferred mechanism, basic auth or
+  no auth are deprecated.
+* Extended and improved the `/notifications` endpoint.
+
 ## [1.1.0] - 2023-05-15 - Giuseppe Lo Presti <lopresti@cern.ch>
 
 * Added a new `/invite-accepted` endpoint to support an invitation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,24 @@
 # Changelog
 
-## [1.2.0] - 2024-07-18 - Giuseppe Lo Presti <lopresti@cern.ch>
+## [1.2.0] - 2024-11-20 - Michiel B. De Jong <michiel@pondersource.com>
 
+* Rephrased and improved the whole protocol description text
+  in order to conform to the IETF Internet Draft style.
+* Updated the API specification to OpenAPI 3.0.
 * Added a `/.well-known` endpoint for discovery, to replace
-  the legacy `/ocm-provider` endpoint in a future release.
-* Added support for Multi-Factor Authentication.
-* Clarified access methods to remote shares: bearer token
-  authorization is the preferred mechanism, basic auth or
-  no auth are deprecated.
-* Extended and improved the `/notifications` endpoint.
+  the legacy `/ocm-provider` endpoint in a future release, and
+  extended the properties and capabilities each implementation
+  can expose.
+* Introduced a concept of `requirements` in new shares, which indicate
+  that a recipient of a share MUST fulfill some capabilities in order
+  to access the share.
+* Introduced several mechanisms to improve security:
+  * Support for Multi-Factor Authentication.
+  * Support for signing requests.
+  * Support for OAuth-style exchanges, via a new `/token` endpoint.
+  * Clarified access methods to remote shares, and deprecated
+    less secure ones.
+* Extended the `/notifications` endpoint.
 
 ## [1.1.0] - 2023-05-15 - Giuseppe Lo Presti <lopresti@cern.ch>
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [1.2.0] - 2024-11-20 - Michiel B. De Jong <michiel@pondersource.com>
+## [1.2.0] - 2024-11-20 - Michiel B. de Jong <michiel@pondersource.com>
 
 * Rephrased and improved the whole protocol description text
   in order to conform to the IETF Internet Draft style.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This repository contains the text of the Open Cloud Mesh IETF Draft, as well as 
 The documents are available as follows:
 
 * Current version under development: [RFC-formatted Draft](IETF-RFC.md) | [API spec](https://cs3org.github.io/OCM-API/docs.html?branch=develop&repo=OCM-API&user=cs3org)
+* Version 1.2: [RFC-formatted Draft](https://github.com/cs3org/OCM-API/blob/v1.2.0/IETF-RFC.md) | [API spec](https://cs3org.github.io/OCM-API/docs.html?branch=v1.2.0&repo=OCM-API&user=cs3org)
 * Version 1.1: [README](https://github.com/cs3org/OCM-API/blob/v1.1.0/README.md) | [API spec](https://cs3org.github.io/OCM-API/docs.html?branch=v1.1.0&repo=OCM-API&user=cs3org)
 * Version 1.0: [API spec](https://cs3org.github.io/OCM-API/docs.html?branch=v1.0.0&repo=OCM-API&user=cs3org)
 

--- a/spec.yaml
+++ b/spec.yaml
@@ -9,7 +9,7 @@ x-origin:
 info:
   title: Open Cloud Mesh API
   description: Open Cloud Mesh Open API Specification.
-  version: 1.1.0
+  version: 1.2.0
   x-logo:
     url: logo.png
 paths:
@@ -335,7 +335,7 @@ components:
         apiVersion:
           type: string
           description: The OCM API version this endpoint supports
-          example: 1.1.0
+          example: 1.2.0
         endPoint:
           type: string
           description: The URI of the OCM API available at this endpoint


### PR DESCRIPTION
As discussed today at the OCM weekly call, we wish to tag OCM v1.2, with the spirit of consolidating the recent improvements and propose the main vendors, Nextcloud, ownCloud, and Seafile, to include the implementation of the new standard in their development plans.

This PR includes a changelog of what comes in the new release. The real changes are already all in the `develop` branch.

I'd like to ask @schiessle, @butonic, @killing to "officially" approve this PR, with a prospected release date of Thursday, 18th July 2024, i.e. in a month from now.

CC @michielbdejong @mickenordin @smesterheide @MahdiBaghbani