### PR TITLE
/invitation-accepted remove 404 status

### DIFF
--- a/spec.yaml
+++ b/spec.yaml
@@ -225,15 +225,11 @@ paths:
           schema:
             $ref: "#/definitions/AcceptedInviteResponse"
         400:
-          description: The invitation token is invalid.
+          description: The invitation token is invalid or does not exist.
           schema:
             $ref: "#/definitions/Error"
         403:
           description: Remote service is not trusted to accept invitations.
-          schema:
-            $ref: "#/definitions/Error"
-        404:
-          description: The invitation token does not exist.
           schema:
             $ref: "#/definitions/Error"
         409:


### PR DESCRIPTION
In #58 this status code was added, I think it ought to be removed in favor of the 400 status code that allready exists, so I made the message clearer.