### PR TITLE
Signing request

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Since there is no way to guarantee that the sharee OCM provider will actually en
 
 ## Signing request
 
-A request is signed by adding the signature in the headers. The sender also need to expose the public key used to generate the signature. The receiver can then validate the signature and therefore the origin of the request.
+A request is signed by adding the signature in the headers. The sender also needs to expose the public key used to generate the signature. The receiver can then validate the signature and therefore the origin of the request.
 To helps debugging, it is made mandatory to also add all properties used in the signature as headers, even if they can be easily re-generated from the payload.  
 
 Note: Signed requests prove the identity of the sender but does not encrypt nor affect its payload.

--- a/README.md
+++ b/README.md
@@ -181,8 +181,7 @@ Here is an example of how to verify the signature using the headers, the signatu
 
 ### Validating the payload
 
-while signed, it is still needed to confirm the validity of the payload.  
-The last step is to ensure that the payload implies action initiated on the behalf the source of the request.  
+Following the validation of the signature, the host should also confirm the validity of the payload, that is ensuring that the actions implied in the payload actually initiated on behalf of the source of the request.
 
 As an example, if the payload is about initiating a new share the file owner has to be an account from the instance at the origin of the request.  
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Here is an example of headers needed to sign a request.
     "date": "Mon, 08 Jul 2024 14:16:20 GMT",
     "digest": "SHA-256=U7gNVUQiixe5BRbp4Tg0xCZMTcSWXXUZI2\\/xtHM40S0=",
     "host": "hostname.of.the.recipient",
-    "Signature": "keyId=\"https://author.hostname/key\",algorithm=\"ras-sha256\",headers=\"content-length date digest host\",signature=\"DzN12OCS1rsA[...]o0VmxjQooRo6HHabg==\""
+    "Signature": "keyId=\"https://author.hostname/key\",algorithm=\"rsa-sha256\",headers=\"content-length date digest host\",signature=\"DzN12OCS1rsA[...]o0VmxjQooRo6HHabg==\""
   }
 ```
 
@@ -141,7 +141,7 @@ This is a quick PHP example of headers for outgoing request:
 		
     $signature = [
         'keyId' => 'https://author.hostname/key',
-        'algorithm' => 'ras-sha256',
+        'algorithm' => 'rsa-sha256',
         'headers' => 'content-length date digest host',
         'signature' => $signed 
     ];

--- a/README.md
+++ b/README.md
@@ -43,8 +43,6 @@ To fill the gap between users knowning other peers' email addresses of the form 
 * A provider SHOULD ensure that a `type=SRV` DNS query to `_ocm._tcp.provider.org` resolves to e.g. `service = 10 10 443 my-cloud-storage.provider.org`
 * When requested to discover the EFSS endpoint for `user@provider.org`, implementations SHOULD query the corresponding `_ocm._tcp.domain` DNS record, e.g. `_ocm._tcp.provider.org`, and subsequently make a HTTP GET request to the host returned by that DNS query, followed by the `/.well-known/ocm` URL path.
 
-
-
 ### Share Creation
 To create a share, the sending server SHOULD make a HTTP POST request to the `/shares` endpoint of the receiving server ([docs](https://cs3org.github.io/OCM-API/docs.html?branch=develop&repo=OCM-API&user=cs3org#/paths/~1shares/post)).
 

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Here is an example of headers needed to sign a request.
 
 - '(request-target)' contains the reached endpoint and the used method,
 - 'content-length' is the total length of the payload of the request,
-- 'date' is the date and time on which the request have been emitted,
+- 'date' is the date and time when the request has been sent,
 - 'digest' is a checksum of the payload of the request,
 - 'host' is the hostname of the recipient of the request (remote when signing outgoing request, local on incoming request),
 - 'Signature' contains the signature generated using the private key and details on its generation:

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ If a finite whitelist of receiver servers exists on the sender side, then this l
 
 When a sending server allows sharing to any internet-hosted receiving server, then discovery can happen from the sharee address, using the `/.well-known/ocm` (or `/ocm-provider`, for backwards compatibility) URL that receiving servers SHOULD provide according to this [specification](https://cs3org.github.io/OCM-API/docs.html?branch=develop&repo=OCM-API&user=cs3org#/paths/~1.well-known~1ocm/get).
 
-If the identity of an incoming request needs to be confirmed, the discovery data SHOULD contain a public key. Each incoming request that requires to origin from an authenticated source must be signed in its headers using the related private key.
+To ease the process of confirming the identity of a remote party, the discovery data MAY contain a public key: each incoming request that requires to origin from an authenticated source MUST be signed in its headers using the private key of that source, whose public key MUST be exposed in its discovery data.
 
 To fill the gap between users knowning other peers' email addresses of the form `user@provider.org`, and the actual cloud storage endpoints being in the form `https://my-cloud-storage.provider.org`, a further discovery mechanism SHOULD be provided by implementations that wish to allow sending shares to any receiver, based on DNS `SRV` Service Records.
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Since there is no way to guarantee that the sharee OCM provider will actually en
 ## Signing request
 
 A request is signed by adding the signature in the headers. The sender also needs to expose the public key used to generate the signature. The receiver can then validate the signature and therefore the origin of the request.
-To helps debugging, it is made mandatory to also add all properties used in the signature as headers, even if they can be easily re-generated from the payload.  
+To help debugging, it is recommended to also add all properties used in the signature as headers, even if they can easily be re-generated from the payload.  
 
 Note: Signed requests prove the identity of the sender but does not encrypt nor affect its payload.
 

--- a/spec.yaml
+++ b/spec.yaml
@@ -357,6 +357,23 @@ definitions:
           enum: ["/notifications", "/invite-accepted", "/mfa-capable"]
         example:
           ["/invite-accepted"]
+      publicKey:
+        type: object
+        description: |
+          The signatory used to sign outgoing request to confirm its origin. The 
+          signatory is optional but it MUST contains `id` and `publicKeyPem`.
+        properties:
+          id:
+            type: string
+            description: |
+              unique id of the key in URI format. The hostname set the origin of the 
+              request and MUST be identical to the current discovery endpoint.
+            example: https://my-cloud-storage.org/ocm#signature
+          publicKeyPem:
+            type: string
+            description: |
+              PEM-encoded version of the public key.
+            example: "-----BEGIN PRIVATE KEY-----\nMII...QDD\n-----END PRIVATE KEY-----\n"
   NewShare:
     type: object
     required:

--- a/spec.yaml
+++ b/spec.yaml
@@ -361,7 +361,7 @@ definitions:
         type: object
         description: |
           The signatory used to sign outgoing request to confirm its origin. The 
-          signatory is optional but it MUST contains `id` and `publicKeyPem`.
+          signatory is optional but it MUST contain `id` and `publicKeyPem`.
         properties:
           id:
             type: string

--- a/spec.yaml
+++ b/spec.yaml
@@ -373,7 +373,7 @@ definitions:
             type: string
             description: |
               PEM-encoded version of the public key.
-            example: "-----BEGIN PRIVATE KEY-----\nMII...QDD\n-----END PRIVATE KEY-----\n"
+            example: "-----BEGIN PUBLIC KEY-----\nMII...QDD\n-----END PUBLIC KEY-----\n"
   NewShare:
     type: object
     required:


### PR DESCRIPTION
This is an attempt to add an way to confirm the origin of an incoming request when running an OCM request to ensure both party known each others

### Signing Request

Signing request allows to confirm the identity of the sender.
Signing request does not encrypt nor affect its payload.
Signing request only adds metadata to the headers of the request.

### Discovery

A signatory containing a keyId and the public key is added to the OCM discovery

```
{
  "enabled": true,
  "endPoint": "...",
  "resourceTypes": [
    [...]
  ],
  "protocols": {
    [...]
  },
  "publicKey": {
    "keyId": "https://cloud.mydomain.com/ocm#signature",
    "publicKeyPem": "[...]"
  }
}
```


### Signature

The concept is to add unique metadata and sign them using a private/public key pair.
The location of the public key used to verify the signature will confirm the origin of the request.

Signature does not affect the data of the request, it only adds headers to it:

```
 {
     "(request-target)": "post /path",
     "content-length": 380,
     "date": "Mon, 08 Jul 2024 14:16:20 GMT",
     "digest": "SHA-256=U7gNVUQiixe5BRbp4Tg0xCZMTcSWXXUZI2\\/xtHM40S0=",
     "host": "hostname.of.the.recipient",
     "Signature": "keyId=\"https://author.hostname/key\",algorithm=\"ras-sha256\",headers=\"content-length date digest host\",signature=\"DzN12OCS1rsA[...]o0VmxjQooRo6HHabg==\""
 }
```
    'content-length' is the total length of the data/content
    'date' is the datetime the request have been initiated
    'digest' is a checksum of the data/content
    'host' is the hostname of the recipient of the request (remote when signing outgoing request, local on incoming request)
    'Signature' contains the signature generated using the private key, and metadata:
        'keyId' is a unique id, formatted as an url. hostname is used to retrieve the public key via custom discovery
        'algorithm' define the algorithm used to generate signature
        'headers' contains a list of element used during the generation of the signature
        'signature' is the encrypted string, using local private key, of an array containing elements
        listed in 'headers' and their value. Some elements (content-length date digest host) are mandatory
        to ensure authenticity override protection.
