### PR TITLE
Advertise any other protocol in the discovery endpoint

### DIFF
--- a/spec.yaml
+++ b/spec.yaml
@@ -320,8 +320,9 @@ definitions:
             protocols:
               type: object
               description: |
-                The supported protocols to access shares at this endpoint.
-                Implementations MUST support `webdav` at a minimum.
+                The supported protocols to access shared resources at this endpoint.
+                Implementations MUST support at least `webdav` for `file` resources,
+                any other combination of resources and protocols is optional.
               properties:
                 webdav:
                   type: string
@@ -329,14 +330,12 @@ definitions:
                     The top-level WebDAV path at this endpoint. In order to access
                     a remote shared resource, implementations MAY use this path
                     as a prefix, or as the full path (see sharing examples).
-                  example: /remote/dav/ocm/
                 webapp:
                   type: string
                   description: |
                     The top-level path for web apps at this endpoint. This value
                     is provided for documentation purposes, and it SHALL NOT
                     be intended as a prefix for share requests.
-                  example: /app/ocm/
                 datatx:
                   type: string
                   description: |
@@ -345,7 +344,17 @@ definitions:
                     NOT be intended as a prefix. In addition, implementations
                     are expected to execute the transfer using WebDAV as
                     the wire protocol.
-                  example: /remote/dav/ocm/
+              patternProperties:
+                "^.*$":
+                  type: string
+                  description: |
+                    Any additional protocol supported for this resource type MAY
+                    be advertised here, where the value MAY correspond to a top-level
+                    URI to be used for that protocol.
+              example:
+                webdav: "/remote/dav/ocm/"
+                webapp: "/app/ocm/"
+                talk: "/apps/spreed/api/"
       capabilities:
         type: array
         description: |


### PR DESCRIPTION
This is a proposal in order to standardize how to show additional protocols in the discovery endpoint.

~~I'm not sure it can be espressed in OpenAPI 2.0. One more reason to convert to OpenAPI 3.0?~~

Edit: I fixed the PR (still with OpenAPI 2.0) so to allow to specify `<any name> : "<url>"`, similar to how Nextcloud advertises their `talk` protocol:
```
      "protocols": {
        "talk-v1": "/ocs/v2.php/apps/spreed/api/"
      }
```
And the included example is deliberately inspired to the above.

@ArtificialOwl this makes Nextcloud's discovery fully standard ;-)