### PR TITLE
Federation type information at discovery endpoint

### DIFF
--- a/spec.yaml
+++ b/spec.yaml
@@ -280,23 +280,23 @@ definitions:
     properties:
       enabled:
         type: boolean
-        description: Whether the OCM service is enabled at this endpoint
+        description: Whether the OCM service is enabled at this endpoint.
       apiVersion:
         type: string
-        description: The OCM API version this endpoint supports
+        description: The OCM API version this endpoint supports.
         example: 1.1.0
       endPoint:
         type: string
-        description: The URI of the OCM API available at this endpoint
+        description: The URI of the OCM API available at this endpoint.
         example: https://my-cloud-storage.org/ocm
       provider:
         type: string
-        description: A friendly branding name of this endpoint
+        description: A friendly branding name of this endpoint.
         example: MyCloudStorage
       federation:
         type: object
         description: |
-          The information about the OCM service federation type and trusted domains at this endpoint
+          The information about the OCM service federation type and trusted domains at this endpoint.
         required:
           - type
         properties:

--- a/spec.yaml
+++ b/spec.yaml
@@ -293,6 +293,39 @@ definitions:
         type: string
         description: A friendly branding name of this endpoint
         example: MyCloudStorage
+      federation:
+        type: object
+        description: |
+          The information about the OCM service federation type and trusted domains at this endpoint
+        required:
+          - type
+        properties:
+          type:
+            type: string
+            description: |
+              A supported federation type (open, closed).
+              The `open` federation means that this enpoint trusts every other server.
+              The `closed` federation means this endpoint only trusts server from it's trusted list.
+            example: open
+          trusted:
+            type: object
+            description: |
+              Optional information about the servers trusted at this endpoint.
+            properties:
+              domains:
+                type: array
+                description: |
+                  Domains trusted by this endpoint.
+                items:
+                  type: string
+                example: ["trusted-cloud-storage.org"]
+              directories:
+                type: array
+                description: |
+                  Directories of domains trusted by this endpoint.
+                items:
+                  type: string
+                example: ["https://iop.sciencemesh.uni-muenster.de/iop/mentix/cs3"]
       resourceTypes:
         type: array
         description: |

--- a/spec.yaml
+++ b/spec.yaml
@@ -325,6 +325,7 @@ definitions:
                   Directories of domains trusted by this endpoint.
                 items:
                   type: string
+                  format: url
                 example: ["https://iop.sciencemesh.uni-muenster.de/iop/mentix/cs3"]
       resourceTypes:
         type: array


### PR DESCRIPTION
This PR change to OCM spec allows the OCM service to let others know if it trusts all servers (hence the type `open`) or only servers from a (or multiple) `directory`(s) (hence the type `closed)`.

In addition to that, an instance MAY decide to trust domains outside of directories too.

Returned JSON in case of trusting everyone:
```json
"federation": {
    "type": "open",
}
```

Returned JSON in case of trusting closed networks:
```json
"federation": {
    "type": "closed",
    "trusted": {
      "domains": [
        "trusted-cloud-storage.org"
      ],
      "directories": [
        "https://iop.sciencemesh.uni-muenster.de/iop/mentix/cs3"
      ]
    }
}
```

I don't like the names `open` and `closed` but I cannot think of anything better.