### PR TITLE
Federated contacts public key exchange and signing

### DIFF
--- a/spec.yaml
+++ b/spec.yaml
@@ -640,6 +640,27 @@ definitions:
             type: string
             description: Name of the user accepting the invite.
             example: Richard Feynman
+          publicKey:
+            type: object
+            description: Public key of the user accepting the invite.
+            properties:
+              keyID:
+                type: string
+                format: url
+                description: Unique ID, formatted as a URL. the hostname is used to retrieve the public key via custom discovery
+                example: "https://my-gpg-keystore.com/key-id"
+              publicKeyPem:
+                type: string
+                example: |
+                  -----BEGIN PUBLIC KEY-----
+                  MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAryQICCl6NZ5gDKrnSztO
+                  3Hy8PEUcuyvg/ikC+VcIo2SFFSf18a3IMYldIugqqqZCs4/4uVW3sbdLs/6PfgdX
+                  7O9D22ZiFWHPYA2k2N744MNiCD1UE+tJyllUhSblK48bn+v1oZHCM0nYQ2NqUkvS
+                  j+hwUU3RiWl7x3D2s9wSdNt7XUtW05a/FXehsPSiJfKvHJJnGOX0BgTvkLnkAOTd
+                  OrUZ/wK69Dzu4IvrN4vs9Nes8vbwPa/ddZEzGR0cQMt0JBkhk9kU/qwqUseP1QRJ
+                  5I1jR4g8aYPL/ke9K35PxZWuDp3U0UPAZ3PjFAh+5T+fc7gzCs9dPzSHloruU+gl
+                  FQIDAQAB
+                  -----END PUBLIC KEY-----
   AcceptedInviteResponse:
     type: object
     allOf:
@@ -656,3 +677,24 @@ definitions:
             type: string
             description: Name of the user that sent the invite.
             example: John Doe
+          publicKey:
+            type: object
+            description: Public key of the user that sent the invite.
+            properties:
+              keyID:
+                type: string
+                format: url
+                description: Unique ID, formatted as an URL. the hostname is used to retrieve the public key via custom discovery
+                example: "https://my-gpg-keystore.com/key-id"
+              publicKeyPem:
+                type: string
+                example: |
+                  -----BEGIN PUBLIC KEY-----
+                  MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAryQICCl6NZ5gDKrnSztO
+                  3Hy8PEUcuyvg/ikC+VcIo2SFFSf18a3IMYldIugqqqZCs4/4uVW3sbdLs/6PfgdX
+                  7O9D22ZiFWHPYA2k2N744MNiCD1UE+tJyllUhSblK48bn+v1oZHCM0nYQ2NqUkvS
+                  j+hwUU3RiWl7x3D2s9wSdNt7XUtW05a/FXehsPSiJfKvHJJnGOX0BgTvkLnkAOTd
+                  OrUZ/wK69Dzu4IvrN4vs9Nes8vbwPa/ddZEzGR0cQMt0JBkhk9kU/qwqUseP1QRJ
+                  5I1jR4g8aYPL/ke9K35PxZWuDp3U0UPAZ3PjFAh+5T+fc7gzCs9dPzSHloruU+gl
+                  FQIDAQAB
+                  -----END PUBLIC KEY-----


### PR DESCRIPTION
In addition to #92 I'd like to create a PR for a similar matter.

I propose to:
1. Sign the requests on behalf of the sender instance (which seems to be **required**).
2. "**Optionally**" also sign the requests on behalf of the sender user and receiver user.

This could be beneficial in:
1. Make sure the sender is the user it claims to be (even if the sender server is authentic)
2. It allows sharing E2EE shares from one vendor to another (this one needs discussion).

Cons:
1. This only works if users do the invite-flow first and then try to share something.