### PR TITLE
Use federatedCloudId instead of email for user identification between servers

### DIFF
--- a/spec.yaml
+++ b/spec.yaml
@@ -654,7 +654,7 @@ definitions:
             example: 9302
           federatedCloudId:
             type: string
-            description: Federated cloud ID of the user accepting the invite. it should be in the form of username@provider-domain.
+            description: Federated cloud ID of the user who sent the invite. it should be in the form of username@provider-domain.
             example: john@sender.org
           email:
             type: string

--- a/spec.yaml
+++ b/spec.yaml
@@ -619,11 +619,6 @@ definitions:
     type: object
     allOf:
       - properties:
-          recipientProvider:
-            type: string
-            format: url
-            description: URL of the receiver OCM service.
-            example: https://receiver.org
           token:
             type: string
             description: Token received in the invite

--- a/spec.yaml
+++ b/spec.yaml
@@ -628,14 +628,18 @@ definitions:
             type: string
             description: Token received in the invite
             example: xyz
-          userID:
+          userId:
             type: string
             description: Unique ID to identify the user at the remote provider accepting the invite.
             example: 51dc30ddc473d43a6011e9ebba6ca770
+          federatedCloudId:
+            type: string
+            description: Federated cloud ID of the user accepting the invite. it should be in the form of username@provider-domain.
+            example: richard@receiver.org
           email:
             type: string
-            description: Email ID of the user accepting the invite.
-            example: richard@receiver.org
+            description: Email of the user accepting the invite.
+            example: richard@gmail.com
           name:
             type: string
             description: Name of the user accepting the invite.
@@ -644,15 +648,19 @@ definitions:
     type: object
     allOf:
       - properties:
-          userID:
+          userId:
             type: string
             description: Unique ID to identify the sender at the local provider.
             example: 9302
+          federatedCloudId:
+            type: string
+            description: Federated cloud ID of the user accepting the invite. it should be in the form of username@provider-domain.
+            example: john@sender.org
           email:
             type: string
-            description: Email ID of the user that sent the invite.
-            example: john@sender.org
+            description: The email of the user who sent the invite.
+            example: john@cern.ch
           name:
             type: string
-            description: Name of the user that sent the invite.
+            description: Name of the user who sent the invite.
             example: John Doe


### PR DESCRIPTION
This PR changes 2 things:

1. Renames `userID` to `userId` to be consistent with `camelCase` across the whole specification eg. `providerId`
2. Adds a field to the `invite-flow` called `federatedCloudId`.
3. Removes `recipientProvider` since it is redundant and is repeated on `federatedCloudId`.

---

**Reason behind the new field**
Previously OCM used email as a way to identify remote users. 

This is essential when a party tries to send a `share` or `notification` to another party because it is going to find the domain name of the recipient from their ID (which currently is set to email, look at `Reva` and `ScienceMesh`)

This becomes problematic when the user's email name or domain is different than the user's username or provider domain. for example:

1. Alice is on provider `apollo.space` with username `alice1998` and has email `alice1998@apollo.space` -> OK
2. Bob is on provider `nasa.space` with username `bob` and has email `bobby@gmail.com` -> Problem

Vendors can overcome this problem by not providing the user's email and just returning username@provider-domain in the email field.

I think it is a good idea to make a distinction between email and `federatedCloudId`.