### PR TITLE
Establishing Contact section

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ Similarly, an interface on the Sending Server, MAY allow any internet user to ty
 ##### Rationale
 Many methods for establishing contact allow unsolicited contact with the prospective Receiving Party whenever that party's OCM Address is known. The Invite Flow requires the Receiving Party to explicitly accept it before it can be used, which establishes bidirectional trust between the two parties involved.
 
+OCM Servers MAY enforce a policy to only accept Shares between such trusted contacts, or MAY display a warning to the Receiving Party when a Share Creation Notification from an unknown Sending Party is received
+
 ##### Steps
 * the Invite Sender OCM Server generates a unique Invite Token and helps the Invite Sender to create the Invite Message
 * the Invite Sender uses some out-of-band communication to send the Invite Message, containing the Invite Token and the Invite Sender OCM Server FQDN, to the Invite Receiver

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Similarly, an interface on the Sending Server, MAY allow any internet user to ty
 ##### Rationale
 Many methods for establishing contact allow unsolicited contact with the prospective Receiving Party whenever that party's OCM Address is known. The Invite Flow requires the Receiving Party to explicitly accept it before it can be used, which establishes bidirectional trust between the two parties involved.
 
-###### Steps
+##### Steps
 * the Invite Sender OCM Server generates a unique Invite Token and helps the Invite Sender to create the Invite Message
 * the Invite Sender uses some out-of-band communication to send the Invite Message, containing the Invite Token and the Invite Sender OCM Server FQDN, to the Invite Receiver
 * the Invite Receiver navigates to the Invite Receiver OCM Server (possibly using a Where-Are-You-From page provided as part of the Invite Message) and makes the Invite Acceptance Gesture


### PR DESCRIPTION
A more thorough paragraph about how to establish contact between Sending Party and Receiving Party.
This is up to the point where the Receiving Server's FQDN is known, this does not yet include server discovery.

This also replaces the existing paragraph about invites:
* fixing #97
* We had a sentence "In addition, the `sender.com` service MAY integrate this interface with [ScienceMesh](https://sciencemesh.io), and only allow a curated white list of sites as receivers." which I don't think is true. Even if the Invite Message takes the form of a ScienceMesh WAYF URL, it easily could be pasted into other EFSSs. The check doesn't come from the use of the WAYF. I did add an extra node in the Invite Acceptance Request and Invite Acceptance Response sections about black/white-listing of servers at that point.
* I changed the terms like 'site' and 'share' a bit to match the terms established in [the PR for the intro section](https://github.com/cs3org/OCM-API/pull/109)