### PR TITLE
Consolidate scope and assumptions section

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,35 +2,45 @@
 
 ![Open Cloud Mesh Protocol Specification](logo.png)
 
-This repository contains the specification of the Open Cloud Mesh protocol, including
-the [OpenAPI](https://github.com/OAI/OpenAPI-Specification) (fka Swagger) specification for its API. This specification describes disovery and use of the RESTful API endpoints, request and response headers, possible response codes, request and response formats, hypermedia controls, error handling, and other API design best practices which vendors should support to make sharing of resources between different vendors possible.
+This repository contains the text of the Open Cloud Mesh Internet-Draft, as well as
+the equivalent [OpenAPI](https://github.com/OAI/OpenAPI-Specification) (fka Swagger) specification for its API.
 
-* [Scope and assumptions](#scope-and-assumptions)
 * [Specification](#specification)
-  * [Discovery](#discovery)
-  * [Share Creation](#create)
-  * [Share Acceptance](#accept)
-  * [Share Access](#access)
-  * [Share Deletion](#unshare)
-  * [Share Updating](#update)
-  * [Resharing](#reshare)
-  * [Invite](#invite)
-  * [Signing Request](#signing-request)
-
+  * [Introduction](#introduction)
+  * [Terms](#terms)
+  * [Establishing Contact](#establishing-contact)
+    * [Direct Entry](#direct-entry)
+    * [Address books](#address-books)
+    * [Public Link Flow](#public-link-flow)
+    * [Public Invite Flow](#public-invite-flow)
+    * [Invite Flow](#invite-flow)
+      * [Rationale](#rationale)
+      * [Steps](#steps)
+      * [Invite Acceptance Request Details](#invite-acceptance-request-details)
+      * [Invite Acceptance Response Details](#invite-acceptance-response-details)
+      * [Further Reading](#further-reading)
+  * [OCM API Discovery](#ocm-api-discovery)
+  * [Share Creation Notification](#share-creation-notification)
+  * [Receiving Party Notification](#receiving-party-notification)
+  * [Share Acceptance Notification](#share-acceptance-notification)
+  * [Resource Access](#resource-access)
+  * [Share Deletion](#share-deletion)
+  * [Share Updating](#share-updating)
+  * [Resharing](#resharing)
+* [Appendix A: Multi Factor Authentication](#appendix-a-multi-factor-authentication)
+* [Appendix B: Request Signing](#appendix-b-request-signing)
+  * [How to generate the Signature for outgoing request](#how-to-generate-the-signature-for-outgoing-request)
+  * [How to confirm Signature on incoming request](#how-to-confirm-signature-on-incoming-request)
+  * [Validating the payload](#validating-the-payload)
+* [Changelog](#changelog)
 * [Contributing](#contributing)
-
-## Scope and assumptions
-
-* For the core sharing functionality, the provider knows the consumer (both endpoint and user) when it creates a share with the consumer (also see [#26](https://github.com/cs3org/OCM-API/issues/26)). In addition, an optional invitation workflow is available in this specification (see below), which gives the consumer a way to automatically trust a provider (and vice versa). The [ScienceMesh](https://sciencemesh.io) infrastructure provides a managed white list of trusted federated sites.
-* Consumer doesn't have to accept a share, the resource will be available to the consumer immediately ([#25](https://github.com/cs3org/OCM-API/issues/25)).
-* Dealing with incoming shares is a vendor specific implementation. One vendor might use an 'accept before' process while another vendor might use a 'decline after' approach. This is considered part of the UX and thus not part of the interaction between different vendors. However, the consumer could notify the provider by using the introduced `/notifications` endpoint (also see [#27](https://github.com/cs3org/OCM-API/issues/27)).
-* Reverting access to outgoing shares is a vendor specific implementation. One vendor might delete an entire share while another might invalidate an access token. This is considered part of vendor-specific internals and thus not part of the interaction between different vendors. However, the provider could notify the consumer by using the introduced `/notifications` endpoint (also see [#27](https://github.com/cs3org/OCM-API/issues/27)).
-* The actual file sync is not part of this specification. To keep this specification 'future proof', the file sync protocol will be embedded as a separate object in Open Cloud Mesh API calls. This protocol object contains all protocol specific options, e.g. WebDAV specific options.
 
 ## Specification
 ### Introduction
 Open Cloud Mesh is a  server federation protocol that is used to notify a remote user that they have
 been granted access to some resource. It has similarities with authorization flows such as OAuth, as well as with social internet protocols such as ActivityPub and email.
+
+The actual file sync is not part of this specification. To keep this specification 'future proof', the file sync protocol will be embedded as a separate object in Open Cloud Mesh API calls. This protocol object contains all protocol specific options, e.g. WebDAV specific options.
 
 ### Terms
 We define the following concepts (with some non-normative references to related concepts from OAuth and elsewhere):
@@ -155,7 +165,7 @@ If the FQDN passes the denylist and/or allowlist checks, but no details about it
 This process MAY be influenced by a VPN connection and/or IP allowlisting.
 
 Otherwise, for instance
-when a sending server allows sharing to any internet-hosted receiving server, then discovery can happen from the Receiving Server FQDN, using `https://<fqdn>/.well-known/ocm` (or `https://<fqdn>/ocm-provider`, for backwards compatibility) as the URL. The Receiving Server SHOULD provide both of these. See the [API specification](https://cs3org.github.io/OCM-API/docs.html?branch=develop&repo=OCM-API&user=cs3org#/paths/~1.well-known~1ocm/get) for a normative definition of both endpoints.
+when a sending server allows sharing to any internet-hosted receiving server, then trust can be established dynamically, and OCM API discovery can happen from the Receiving Server FQDN, using `https://<fqdn>/.well-known/ocm` (or `https://<fqdn>/ocm-provider`, for backwards compatibility) as the URL. The Receiving Server SHOULD provide both of these. See the [API specification](https://cs3org.github.io/OCM-API/docs.html?branch=develop&repo=OCM-API&user=cs3org#/paths/~1.well-known~1ocm/get) for a normative definition of both endpoints.
 
 To help with situations where hosting `https://<fqdn>/.well-known/ocm` or `https://<fqdn>/ocm-provider` is impractical, a further discovery mechanism MAY be provided, based on DNS `SRV` Service Records.
 
@@ -239,6 +249,8 @@ Additionally, if `protocol.<protocolname>.permissions` include `mfa-enforced`, t
 ### Share Deletion
 A `"SHARE_ACCEPTED"` notification followed by a `"SHARE_UNSHARED"` notification is
 equivalent to a `"SHARE_DECLINED"` notification.
+
+Reverting access to outgoing shares is a vendor specific implementation. One vendor might delete an entire share while another might invalidate an access token. This is considered part of vendor-specific internals and thus not part of the interaction between different vendors. However, the provider could notify the consumer by using the introduced `/notifications` endpoint (also see [#27](https://github.com/cs3org/OCM-API/issues/27)).
 
 ### Share Updating
 TODO: document `"RESHARE_CHANGE_PERMISSION"`

--- a/README.md
+++ b/README.md
@@ -161,11 +161,32 @@ If `https://<fqdn>/.well-known/ocm` does not exist, the Receiving Server MAY ins
 
 When attempting to discover the OCM API details for `<fqdn>`, if https://<fqdn>/.well-known/ocm can not be fetched, implementations SHOULD fall back to querying the corresponding `_ocm._tcp.<fqdn>` DNS record, e.g. `_ocm._tcp.provider.org`, and subsequently make a HTTP GET request to the host returned by that DNS query, followed by the `/.well-known/ocm` URL path, using TLS.
 
-### Share Creation
-To create a share, the sending server SHOULD make a HTTP POST request to the `/shares` endpoint of the receiving server ([docs](https://cs3org.github.io/OCM-API/docs.html?branch=develop&repo=OCM-API&user=cs3org#/paths/~1shares/post)).
+### Share Creation Notification
+To create a share, the sending server SHOULD make a HTTP POST request
+* to the `/shares` path in the Invite Sender OCM Server's OCM API
+* using `application/json` as the `Content-Type` HTTP request header
+* its request body containing a JSON document representing an object with the fields as described in the ([API docs](https://cs3org.github.io/OCM-API/docs.html?branch=develop&repo=OCM-API&user=cs3org#/paths/~1shares/post))
+* using TLS
+* using [httpsig](https://datatracker.ietf.org/doc/html/draft-cavage-http-signatures-12)
 
-### Share Acceptance
-In response to a share creation, the receiving server MAY send back a [notification](https://cs3org.github.io/OCM-API/docs.html?branch=develop&repo=OCM-API&user=cs3org#/paths/~1notifications/post) to the sending server, with  `notificationType` set to `"SHARE_ACCEPTED"` or `"SHARE_DECLINED"`. The sending server MAY expose this information to the end user.
+The Receiving Server MAY discard the notification if any of the following hold true:
+* the HTTP Signature is missing
+* the HTTP Signature is not valid
+* no keypair is trusted or discoverable from the FQDN part of the `sender` field in the request body
+* the keypair used to generate the HTTP Signature doesn't match the one trusted or discoverable from the FQDN part of the `sender` field in the request body
+* the Sending Server is denylisted
+* the Sending Server is not allowlisted
+* the Sending Party is not trusted by the Receiving Party (i.e. the Sending Party's OCM Address does not appear in the Receiving Party's addressbook)
+* the Receiving Server is unable to act as an API client for (any of) the protocol(s) listed for accessing the resource
+* an initial check shows that the resource cannot successfully accessed through (any of) the protocol(s) listed
+
+### Receiving Party Notification
+If the Share Creation Notification is not discarded by the Receiving Server, they MAY notify the Receiving Party passively by adding the Share to some inbox list, and MAY also notify them actively through for instance a push notification or an email message.
+
+They could give the Receiving Party the option to accept or reject the share, or add the share automatically and only send an informational notification that this happened.
+
+### Share Acceptance Notification
+In response to a Share Creation Notification, the Receiving Server MAY send back a [notification](https://cs3org.github.io/OCM-API/docs.html?branch=develop&repo=OCM-API&user=cs3org#/paths/~1notifications/post) to the Sending Server, with  `notificationType` set to `"SHARE_ACCEPTED"` or `"SHARE_DECLINED"`. The Sending Server MAY expose this information to the Sending Party.
 
 ### Share Access
 To access a share, the receiving server MAY use multiple ways, depending on the received payload and on the `protocol.name` property:

--- a/README.md
+++ b/README.md
@@ -188,17 +188,18 @@ They could give the Receiving Party the option to accept or reject the share, or
 ### Share Acceptance Notification
 In response to a Share Creation Notification, the Receiving Server MAY send back a [notification](https://cs3org.github.io/OCM-API/docs.html?branch=develop&repo=OCM-API&user=cs3org#/paths/~1notifications/post) to the Sending Server, with  `notificationType` set to `"SHARE_ACCEPTED"` or `"SHARE_DECLINED"`. The Sending Server MAY expose this information to the Sending Party.
 
-### Share Access
-To access a share, the receiving server MAY use multiple ways, depending on the received payload and on the `protocol.name` property:
+### Resource Access
+To access the Resource, the Receiving Server MAY use multiple ways, depending on the body of the Share Creation Notification and on the `protocol.name` property in there:
 
-* If `protocol.name` = `multi`, the receiver MUST make a HTTP PROPFIND request to `protocol.webdav.uri` to access the remote share. If `protocol.webdav.sharedSecret` is not empty, the receiver MUST pass it as a `Authorization: bearer` header.
-Otherwise, if `protocol.webdav.code` is not empty, the receiver SHOULD discover the sender's OCM endpoint and make a signed POST request to `<OCM endpoint>/token`, to exchange
+* If `protocol.name` = `multi`, the receiver MUST make a HTTP PROPFIND request to `protocol.webdav.uri` to access the remote share.
+If `code` is not empty, the receiver SHOULD discover the sender's OCM endpoint and make a signed POST request to the `/token` path inside the Sending Server's OCM API, to exchange
 the code for a short-lived bearer token,
-and then use that bearer token to access the remote share.
+and then use that bearer token to access the Resource.
+Otherwise, if `protocol.webdav.sharedSecret` is not empty, the receiver MUST pass it as a `Authorization: bearer` header.
 
-* If `protocol.name` = `webdav`, the receiver SHOULD inspect the `protocol.options` property. If it contains a `sharedSecret`, as in the [legacy example](https://cs3org.github.io/OCM-API/docs.html?branch=develop&repo=OCM-API&user=cs3org#/paths/~1shares/post), then the receiver SHOULD make a HTTP PROPFIND request to `https://<sharedSecret>:@<host><path>`, where `<host>` is the remote server, and `<path>` is obtained by querying the [Discovery](#discovery) endpoint at the remote server and getting `resourceTypes[0].protocols.webdav`. Note that this access method is _deprecated_ and may be removed in a future release of the Protocol.
+* If `protocol.name` = `webdav`, the receiver SHOULD inspect the `protocol.options` property. If it contains a `sharedSecret`, as in the [legacy example](https://cs3org.github.io/OCM-API/docs.html?branch=develop&repo=OCM-API&user=cs3org#/paths/~1shares/post), then the receiver SHOULD make a HTTP PROPFIND request to `https://<sharedSecret>:@<host><path>`, where `<host>` is the remote server, and `<path>` is obtained by querying the [Discovery](#discovery) endpoint at the Sending Server and getting `resourceTypes[0].protocols.webdav`. Note that this access method is _deprecated_ and may be removed in a future release of the Protocol.
 
-In both cases, when the share is a folder and the receiver accesses a resource within the share, it SHOULD append its relative path to that URL.
+In both cases, when the Resource is a folder and the Receiving Server accesses a resource within that shared folder, it SHOULD append its relative path to that URL.
 
 Additionally, if `protocol.<protocolname>.permissions` include `mfa-enforced`, the receiving host MUST ensure that the user accessing the resource has been authenticated with MFA.
 
@@ -215,13 +216,13 @@ receiving server to persuarde the sending server to share the same resource with
 TODO: document how receiver.com can know if sender.com understood and processed the
 reshare request.
 
-### Multi Factor Authentication
-If an OCM provider exposes the capability `/mfa-capable`, it indicates that it will try and comply with a MFA requirement set as a permission on a share. If the sharer OCM provider trusts the receiver OCM provider, the sharer MAY set the permission `mfa-enforced` on a share, which SHOULD be honored. A compliant OCM provider that signals that it is MFA-capable MUST not allow access to a resource protected with the `mfa-enforced` permission, if the consumer has not provided a second factor to establish their identity with greater confidence.
+## Appendix A: Multi Factor Authentication
+If a Receiving Server exposes the capability `/mfa-capable`, it indicates that it will try and comply with a MFA requirement set as a permission on a Share. If the Sending Server trusts the Receiving Server, the Sending Server MAY set the permission `mfa-enforced` on a Share, which the Receiving Server SHOULD honor. A compliant Receiving Server that signals that it is MFA-capable MUST not allow access to a resource protected with the `mfa-enforced` permission, if the Receiving Party has not provided a second factor to establish their identity with greater confidence.
 
-Since there is no way to guarantee that the sharee OCM provider will actually enforce the MFA requirement, it is up to the sharer OCM provider to establish a trust with the OCM sharee provider such that it is reasonable to assume that the sharee OCM provider will honor the MFA requirement. This establishment of trust will inevitably be implementation dependent, and can be done for example using a pre approved allow list of trusted OCM providers. The procedure of establishing trust is out of scope for this specification: a mechanism similar to the [ScienceMesh](https://sciencemesh.io) integration for the [Invite](#invite) capability may be envisaged.
+Since there is no way to guarantee that the Receiving Server will actually enforce the MFA requirement, it is up to the Sending Server to establish a trust with the Receiving Server such that it is reasonable to assume that the Receiving Server will honor the MFA requirement. This establishment of trust will inevitably be implementation dependent, and can be done for example using a pre approved allow list of trusted Receiving Servers. The procedure of establishing trust is out of scope for this specification: a mechanism similar to the [ScienceMesh](https://sciencemesh.io) integration for the [Invite](#invite) capability may be envisaged.
 
 
-## Signing request
+## Appendix B: Request Signing
 
 A request is signed by adding the signature in the headers. The sender also needs to expose the public key used to generate the signature. The receiver can then validate the signature and therefore the origin of the request.
 To help debugging, it is recommended to also add all properties used in the signature as headers, even if they can easily be re-generated from the payload.
@@ -269,7 +270,7 @@ This is a quick PHP example of headers for outgoing request:
     ];
 
     openssl_sign(implode("\n", $headers), $signed, $privateKey, OPENSSL_ALGO_SHA256);
-		
+
     $signature = [
         'keyId' => 'https://author.hostname/key',
         'algorithm' => 'rsa-sha256',

--- a/spec.yaml
+++ b/spec.yaml
@@ -236,6 +236,27 @@ paths:
           description: Invitation already accepted.
           schema:
             $ref: "#/definitions/Error"
+  /token:
+    post:
+      summary: Obtain a (potentially short-lived) bearer token in exchange for a code
+      description: >
+        See https://github.com/cs3org/OCM-API?tab=readme-ov-file#share-access
+      parameters:
+        - name: token-request
+          in: body
+          description: The JSON request body.
+          required: true
+          schema:
+            $ref: "#/definitions/TokenRequest"
+      responses:
+        200:
+          description: Token issued.
+          schema:
+            $ref: "#/definitions/TokenResponse"
+        403:
+          description: Token denied.
+          schema:
+            $ref: "#/definitions/Error"
 
 definitions:
   "400":
@@ -460,6 +481,10 @@ definitions:
           The expiration time for the OCM share, in seconds
           of UTC time since Unix epoch. If omitted, it is assumed
           that the share does not expire.
+      code:
+        type: string
+        description: |
+          A nonce to be exchanged for a (potentially short-lived) bearer token at the Sending Server's /token endpoint.
       protocol:
         type: object
         description: |
@@ -684,3 +709,40 @@ definitions:
             type: string
             description: Name of the user that sent the invite.
             example: John Doe
+  TokenRequest:
+    type: object
+    allOf:
+      - properties:
+          client_id:
+            type: string
+            format: fqdn
+            description: FQDN of the Receiving Server.
+            example: receiver.org
+          code:
+            type: string
+            description: Code received in the Share Creation Notification
+            example: xyz
+          grant_type:
+            type: string
+            description: Must be set to 'ocm_authorization_code'
+            example: ocm_authorization_code
+  TokenResponse:
+    type: object
+    allOf:
+      - properties:
+          access_token:
+            type: string
+            description: The bearer token to be used to access the protocol-specific API(s)
+            example: asdfgh
+          token_type:
+            type: string
+            description: Must be set to 'bearer'
+            example: bearer
+          expires_in:
+            type: number
+            description: Number of seconds before this access_token will need to be refreshed.
+            example: 3600
+          refresh_token:
+            type: string
+            description: A refresh token
+            example: qwertyuiop


### PR DESCRIPTION
This is in preparation for switching to Internet Draft format. Internet Drafts don't usually have a scope and assumptions section, and most of it is already covered in the main text anyway, so this PR moves the remaining points from there into the appropriate section.