### PR TITLE
Reworded the protocols section of a new share

### DIFF
--- a/spec.yaml
+++ b/spec.yaml
@@ -494,13 +494,13 @@ definitions:
       expiration:
         type: integer
         description: |
-          The expiration time for the OCM share, in seconds
-          of UTC time since Unix epoch. If omitted, it is assumed
-          that the share does not expire.
+          The expiration time for the share, in seconds of UTC time since
+          Unix epoch. If omitted, it is assumed that the share does not expire.
       code:
         type: string
         description: |
-          A nonce to be exchanged for a (potentially short-lived) bearer token at the Sending Server's /token endpoint.
+          A nonce to be exchanged for a (potentially short-lived) bearer token
+          at the Sending Server's `/token` endpoint.
       protocol:
         type: object
         description: |
@@ -529,6 +529,7 @@ definitions:
                 Warning: client implementers should be aware that v1.1 servers
                 MAY support both `webdav` and `multi`, but v1.0 servers MAY
                 only support `webdav`.
+                This field may be removed in a future major version of the spec.
             options:
               type: object
               description: |
@@ -561,10 +562,8 @@ definitions:
                   type: string
                   description: |
                     An URI to access the remote resource. The URI MAY be relative,
-                    in which case the prefix exposed by the `/ocm-provider` endpoint MUST
-                    be used, or it may be absolute (recommended). Additionally, the URI
-                    MAY include a secret hash in the path, in which case there MAY be
-                    no associated `sharedSecret`.
+                    in which case the prefix exposed by the `/.well-known/ocm` endpoint MUST
+                    be used, or it may be absolute (recommended).
             webapp:
               type: object
               properties:
@@ -572,10 +571,10 @@ definitions:
                   type: string
                   description: |
                     A templated URI to a client-browsable view of the shared resource,
-                    such that users may use the web applications available at the site.
-                    The URI MAY include a secret hash in the path. If the path includes
-                    a `{relative-path-to-shared-resource}` placeholder, implementations
-                    MAY replace it with the actual path to ease user interaction.
+                    such that users may use a web application available at the sender site.
+                    If the path includes a `{relative-path-to-shared-resource}` placeholder,
+                    implementations SHOULD replace it with the actual path to ease user
+                    interaction.
                 viewMode:
                   type: string
                   description: |
@@ -590,8 +589,13 @@ definitions:
                 sharedSecret:
                   type: string
                   description: |
-                    An optional secret to be used to access the remote web app,
-                    for example in the form of a bearer token.
+                    An optional secret to be used to access the remote web app, such as
+                    a bearer token. To prevent leaking it in logs it MUST NOT appear
+                    in any URI. If a `code` is provided, then the sending host MUST
+                    accept the short-lived bearer token when serving the web app,
+                    which was already exchanged on the first WebDAV-based interaction
+                    with the recipient of the share. In this case, the `sharedSecret`
+                    SHOULD be omitted.
             datatx:
               type: object
               properties:
@@ -604,12 +608,18 @@ definitions:
                 srcUri:
                   type: string
                   description: |
-                    An URI to access the remote resource. The URI MAY be relative,
-                    in which case the prefix exposed by the `/ocm-provider` endpoint MUST
-                    be used, or it may be absolute (recommended). Additionally, the
-                    URI MAY include a secret hash in the path.
+                    An absolute URI to access the resource at the sending server.
                 size:
                   type: integer
+                  description: |
+                    The size of the file to be transferred from the sending server.
+          patternProperties:
+            "^.*$":
+              type: object
+              description: |
+                An optional additional protocol supported for this resource, with any custom
+                payload. Appropriate capabilities MUST be advertised in order for
+                a sender to ensure the recipient can parse such customized payloads.
         example:
           singleProtocolLegacy:
             name: "webdav"
@@ -617,16 +627,13 @@ definitions:
               sharedSecret: "hfiuhworzwnur98d3wjiwhr"
               permissions: "some permissions scheme"
           singleProtocolNew:
-            name: "webdav"
-            options:
-              sharedSecret: "hfiuhworzwnur98d3wjiwhr"
+            name: "multi"
             webdav:
               sharedSecret: "hfiuhworzwnur98d3wjiwhr"
               permissions: ["read", "write"]
               uri: "https://open-cloud-mesh.org/remote/dav/ocm/7c084226-d9a1-11e6-bf26-cec0c932ce01/path/to/resource.txt"
           multipleProtocols:
             name: "multi"
-            options:
             webdav:
               sharedSecret: "hfiuhworzwnur98d3wjiwhr"
               permissions: ["read", "mfa-enforced"]

--- a/spec.yaml
+++ b/spec.yaml
@@ -519,9 +519,9 @@ definitions:
             name:
               type: string
               description: |
-                The name of the protocol. If `multi` is given, one or more protocol
-                endpoints are expected to be defined according to the optional
-                properties specified below.
+                The name of the protocol. Default: `multi`.
+                If `multi` is given, one or more protocol endpoints are expected
+                to be defined according to the optional properties specified below.
                 Otherwise, at least `webdav` is expected to be supported, and
                 its options MAY be given in the opaque `options` payload for
                 compatibility with v1.0 implementations (see examples). Note
@@ -542,9 +542,11 @@ definitions:
                 sharedSecret:
                   type: string
                   description: |
-                    An optional secret to be used to access the resource,
-                    such as a bearer token.
-                    To prevent leaking it in logs it MUST NOT appear in any URI.
+                    An optional secret to be used to access the resource, such as
+                    a bearer token. If a `code` is provided, it SHOULD be used
+                    instead via the code flow interaction, and the `sharedSecret`
+                    SHOULD be omitted. To prevent leaking it in logs it MUST NOT
+                    appear in any URI.
                 permissions:
                   type: array
                   items:
@@ -593,18 +595,21 @@ definitions:
                     a bearer token. To prevent leaking it in logs it MUST NOT appear
                     in any URI. If a `code` is provided, then the sending host MUST
                     accept the short-lived bearer token when serving the web app,
-                    which was already exchanged on the first WebDAV-based interaction
-                    with the recipient of the share. In this case, the `sharedSecret`
-                    SHOULD be omitted.
+                    which can be exchanged in the code flow interaction. The exchange
+                    MAY already have happened if the recipient accessed the underlying
+                    resource via WebDAV, in a multi-protocol scenario. In this case,
+                    the `sharedSecret` SHOULD be omitted.
             datatx:
               type: object
               properties:
                 sharedSecret:
                   type: string
                   description: |
-                    An optional secret to be used to access the resource,
-                    for example in the form of a bearer token.
-                    To prevent leaking it in logs it MUST NOT appear in any URI.
+                    An optional secret to be used to access the resource, such as
+                    a bearer token. If a `code` is provided, it SHOULD be used
+                    instead via the code flow interaction, and the `sharedSecret`
+                    SHOULD be omitted. To prevent leaking it in logs it MUST NOT
+                    appear in any URI.
                 srcUri:
                   type: string
                   description: |

--- a/spec.yaml
+++ b/spec.yaml
@@ -622,9 +622,10 @@ definitions:
             "^.*$":
               type: object
               description: |
-                An optional additional protocol supported for this resource, with any custom
-                payload. Appropriate capabilities MUST be advertised in order for
-                a sender to ensure the recipient can parse such customized payloads.
+                Any optional additional protocols supported for this resource MAY
+                be provided here, along with their custom payload. Appropriate
+                capabilities MUST be advertised in order for a sender to ensure
+                the recipient can parse such customized payloads.
         example:
           singleProtocolLegacy:
             name: "webdav"


### PR DESCRIPTION
As discussed I reworded the `protocols` section, and removed some inconsistencies.

This fixes #125 and #104 (the removal of `protocol.name` is postponed to OCM 2.0). 