### PR TITLE
Drop DNS-based discovery (and vanity addresses)

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,6 @@ We define the following concepts (with some non-normative references to related 
 * __Discoverable Server__ - a server that tries to supply information in OCM API discovery
 * __OCM Address__ - a string of the form `<Receiving Party's identifier>@<fqdn>` which can be used to uniquely identify a user or group "at" an OCM Server. `<Receiving Party's identifier>` is an opaque string,
 unique at the server. `<fqdn>` is the Fully Qualified Domain Name by which the server is identified. This can, but doesn't need to be, the domain at which the OCM API of that server is hosted.
-* __Vanity OCM Address__ - a string that looks like an OCM Address but with an alternative (generally shorter or nicer) FQDN. This FQDN does not support HTTP-based discovery, but it does provide an SRV record in its DNS zone, pointing to the (generally longer or uglier) FQDN of the OCM Server.
-* __Regular OCM Address__ - an OCM Address that is not a Vanity OCM Address
 * __OCM Notification__ - a message from the Receiving Server to the Sending Server or vice versa, using the OCM Notifications endpoint.
 * __Invite Message__ - out-of-band message used to establish contact between parties and servers in the Invite Flow, containing an Invite Token (see below) and the Invite Sender's OCM Address
 * __Invite Sender__ - the party sending an Invite
@@ -229,10 +227,8 @@ Step 2: The Discovering Server SHOULD attempt OCM API discovery a HTTP GET reque
 Step 3: If that results in a valid HTTP response with a valid JSON response body within reasonable time, go to step 8.
 Step 4: If not, try a HTTP GET with `https://<fqdn>/ocm-provider` as the URL instead.
 Step 5: If that results in a valid HTTP response with a valid JSON response body within reasonable time, go to step 8.
-Step 6: If not, and the `<fqdn>` came from an OCM Address, then it SHOULD check if the OCM Address in question was a Vanity OCM Address.
-This can be checked with a `type=SRV` DNS query to `_ocm._tcp.<fqdn>`. If that returns `service = 10 10 443 <regular-fqdn>` then repeat from step 2, using `<regular-fqdn>` instead of the `<fqdn>` that appeared in the Vanity OCM Address.
-Step 7: If not, fail.
-Step 8: The JSON response body is the data that was discovered.
+Step 6: If not, fail.
+Step 7: The JSON response body is the data that was discovered.
 
 ## Fields
 The JSON response body offered by the Discoverable Server SHOULD contain the following information about its OCM API:
@@ -455,7 +451,6 @@ They could give the Receiving Party the option to accept or reject the share, or
 # Share Acceptance Notification
 In response to a Share Creation Notification, the Receiving Server MAY discover the OCM API of the Sending Server,
 starting from the `<fqdn>` part of the `sender` field in the Share Creation Notification.
-Note that the `sender` field is not allowed to contain a Vanity OCM Address, so the fallback to SRV DNS records is not necessary in this OCM API discovery process.
 
 If the OCM API of the Sending Server is successfully discovered, the Receiving Server MAY
 make a HTTP POST request

--- a/spec.yaml
+++ b/spec.yaml
@@ -36,7 +36,6 @@ paths:
       description: >
         Following RFC 8615, this endpoint returns the properties and capabilities
         offered by an OCM Server. This endpoint is to be served at the OCM server's FQDN,
-        or at the discovery FQDN that its SRV DNS record redirects to,
         e.g. as in `https://my-cloud-storage.org/.well-known/ocm`.
         See [OCM API Discovery](https://github.com/cs3org/OCM-API/tree/internet-draft-format?tab=readme-ov-file#ocm-api-discovery) for more details.
       responses:


### PR DESCRIPTION
As discussed in Thursday's weekly call, I think that vanity OCM addresses are a nice-to-have if people put their vanity OCM address on their business card, memorise it, transmit it verbally, and enter it into a GUI by hand.

But despite this appeal, it also has a number of downsides:
* due to the nature of SRV records, it can only point to a server and a port, so there the discovery process still requires a file hosted on `/.well-known/ocm` or on `/ocm-provider`. It makes it easier for enterprise devops team who don't want to edit the paths of their main domain, but it still requires the EFSS to host the discovery document in those two places. That's why it's not an alternative discovery mechanism but just an additional first step, after which the `.well-known` discovery mechanism still works as usual. Therefore, SRV records do not replace `.well-known` documents; all they can do is change a `labkode@cernbox.cern.ch` address to a shorter ("vanity") `labkode@cern.ch` address.
* it only works if the receiving server offers it AND the sending server is able to query it
* current landscape is 0% of potential sending OCM servers out there support it
* before a receiving user can confidently put their vanity OCM address on their business card, if they don't want cause more than 1% errors, they would have to wait for the servers of 99% of their coworkers to support SRV record discovery. So we would have to add the requirement to the spec now, then wait a long time probably (maybe 10 years?) before 99% of OCM servers out there support it, and then it would start paying off. This feels like a huge investment. It might be faster in smaller closed networks such as ScienceMesh, but there it's not useful (see below)
* vanity OCM addresses will still in some use cases have a long and not-memorable user-id part. For instance in the design of ScienceMesh, the part before the `@` sign is called 'opaque id', and what is the use of being able to say your OCM address is `94aa328533a01084c40c0a6034fc899dba80b3334b85572fc048074004fc8f60@cern.ch`? Then the advantage of vanity addresses is gone, and you might as well say it's `94aa328533a01084c40c0a6034fc899dba80b3334b85572fc048074004fc8f60@cernbox.cern.ch`.
* The main two downsides of vanity addresses are probably the following. We have seen the immense security improvements we can make with invites. An invite flow ensures that both the sending server and the receiving server are "real" EFSS servers on which either the sending or the receiving server logged in (therefore pledging their trust) to either generate or redeem an invite. So we want users to share Invite Messages and NOT OCM addresses in their out-of-band contact messages. In the invite flow, the users never see their OCM address or that of their contact, so having vanity addresses is at best useless there, and maybe even a distraction, foot-gun or anti-pattern.
* We have limited energy, both within the OCM project itself and at vendors who we need to ask to implement spec changes and we want to spend it wisely. If we ask vendors now to implement a DNS query module, and then the next month we ask them to implement invites, we will have used up our ammunition and we risk them saying no to the second request.



We roughly agreed to this in Thursday's weekly meeting, but I would like to get a review from @labkode since the SRV lookup was sort of his "baby", and he may have some arguments for us to reconsider.