### PR TITLE
use-code as new requirement + cleaned up superseded references to mfa-capable

### DIFF
--- a/IETF-RFC.md
+++ b/IETF-RFC.md
@@ -402,9 +402,13 @@ If `multi` is given, one or more protocol
                       - `read` allows read-only access including download of a copy.
                       - `write` allows create, update, and delete rights on the resource.
                       - `share` allows re-share rights on the resource.
-                      - `mfa-enforced` requires the user accessing the resource to be
-                        MFA-authenticated. This permission MAY be used if the
-                        provider exposes the `mfa-capable` capability.
+     * OPTIONAL requirements (array of strings) -
+                      The requirements that the sharee MUST fulfill to access the resource. A subset of:
+                      - `mfa-enforced` requires the consumer to be MFA-authenticated. This
+                        MAY be used if the recipient provider exposes the `enforce-mfa` capability.
+                      - `use-code` requires the consumer to exchange the given `code` via a
+                        signed HTTPS request. This MAY be used if the recipient provider exposes
+                        the `receive-code` capability.
      * OPTIONAL uri (string)
                     An URI to access the remote resource. The URI MAY be relative,
                     in which case the prefix exposed by the `/ocm-provider` endpoint MUST
@@ -423,9 +427,6 @@ If `multi` is given, one or more protocol
                     - `view` allows access to the web app in view-only mode.
                     - `read` allows read and download access via the web app.
                     - `write` allows full editing rights via the web app.
-                    - `mfa-enforced` requires the user accessing the resource to be
-                      MFA-authenticated. This permission MAY be used if the
-                      provider exposes the `mfa-capable` capability.
      * OPTIONAL sharedSecret (string)
                     An optional secret to be used to access the remote web app,
                     for example in the form of a bearer token.
@@ -496,7 +497,7 @@ To access the Resource, the Receiving Server MAY use multiple ways, depending on
 
 In all cases, in case the Shared Resource is a folder and the Receiving Server accesses a resource within that shared folder, it SHOULD append its relative path to that URL. In other words, the Sending Server SHOULD support requests to URLs such as `https://<sender-host><sender-ocm-path>/path/to/resource.txt`.
 
-Additionally, if `protocol.<protocolname>.requirements` includes `mfa-enforced`, the Receiving Server MUST ensure that the Receiving Party has been authenticated with MFA.
+Additionally, if `protocol.<protocolname>.requirements` includes `mfa-enforced`, the Receiving Server MUST ensure that the Receiving Party has been authenticated with MFA, or prompt the consmer in order to elevate their session, if applicable.
 
 # Share Deletion
 A `"SHARE_ACCEPTED"` notification followed by a `"SHARE_UNSHARED"` notification is
@@ -514,7 +515,7 @@ TODO: document how the Receiving Party can know if the Sending Party understood 
 reshare request.
 
 # Appendix A: Multi Factor Authentication
-If a Receiving Server exposes the capability `/mfa-capable`, it indicates that it will try and comply with a MFA requirement set on a Share. If the Sending Server trusts the Receiving Server, the Sending Server MAY set the requirement `mfa-enforced` on a Share, which the Receiving Server MUST honor. A compliant Receiving Server that signals that it is MFA-capable MUST not allow access to a resource protected with the `mfa-enforced` requirement, if the Receiving Party has not provided a second factor to establish their identity with greater confidence.
+If a Receiving Server exposes the capability `enforce-mfa`, it indicates that it will try and comply with a MFA requirement set on a Share. If the Sending Server trusts the Receiving Server, the Sending Server MAY set the requirement `mfa-enforced` on a Share, which the Receiving Server MUST honor. A compliant Receiving Server that signals that it is MFA-capable MUST not allow access to a resource protected with the `mfa-enforced` requirement, if the Receiving Party has not provided a second factor to establish their identity with greater confidence.
 
 Since there is no way to guarantee that the Receiving Server will actually enforce the MFA requirement, it is up to the Sending Server to establish a trust with the Receiving Server such that it is reasonable to assume that the Receiving Server will honor the MFA requirement. This establishment of trust will inevitably be implementation dependent, and can be done for example using a pre approved allow list of trusted Receiving Servers. The procedure of establishing trust is out of scope for this specification: a mechanism similar to the [ScienceMesh](https://sciencemesh.io) integration for the [Invite](#invite-flow) capability may be envisaged.
 

--- a/spec.yaml
+++ b/spec.yaml
@@ -564,12 +564,17 @@ definitions:
                       A list of requirements that the recipient provider MUST fulfill
                       to access the resource. Requirements are optional, but if it is
                       present it MUST NOT be empty. A recipient provider MUST reject
-                      a share whose requirements it does not understand. Currently,
-                      the only requirement supported is:
+                      a share whose requirements it does not understand.
+                      The following requirements are currently supported:
                       - `mfa-enforced` requires the user accessing the resource to be
                         MFA-authenticated. This requirement MAY be used if the
-                        provider exposes the `mfa-capable` capability.
-                    enum: ["mfa-enforced"]
+                        recipient provider exposes the `enforce-mfa` capability.
+                      - `request-signed` requires the recipient to exchange the given
+                        `code` via a signed HTTPS request to `/token` at the Sending
+                        Server, in order to get a short-lived token to be used for
+                        subsequent access. This requirement MAY be used if the
+                        recipient provider exposes the `receive-code` capability.
+                    enum: ["mfa-enforced", "request-signed"]
             webapp:
               type: object
               properties:

--- a/spec.yaml
+++ b/spec.yaml
@@ -117,26 +117,6 @@ paths:
               type: string
           schema:
             $ref: "#/definitions/Error"
-  /mfa-capable:
-    get:
-      summary: Inform the sender that the provider will enforce MFA requirements.
-      description: >
-        Signal that this OCM provider has the capability to enforce MFA when accessing
-        remote shares.
-        A sender MAY set the permission `mfa-enforced` on a share to this provider:
-        when a consumer attempts to access such a share, the consumer server SHOULD
-        enforce, prior to access, that a session exists for the consumer and that
-        it has been authenticated with MFA, or prompt the consumer in order to
-        elevate their session to MFA if that is applicable.
-        Note: there is no guarantee that the consumer service actually enforces any MFA
-        requirements, so a trust must be established before relying on this capability.
-      responses:
-        "200":
-          description: |
-            The provider claims that it is capable of enforcing MFA requirements.
-        "404":
-          description: |
-            The provider does not have the capability to enforce MFA requirements.
   /notifications:
     post:
       summary: Send a notification to a remote party about a previously known entity
@@ -597,10 +577,7 @@ definitions:
                     - `view` allows access to the web app in view-only mode.
                     - `read` allows read and download access via the web app.
                     - `write` allows full editing rights via the web app.
-                    - `mfa-enforced` requires the user accessing the resource to be
-                      MFA-authenticated. This permission MAY be used if the
-                      provider exposes the `mfa-capable` capability.
-                  enum: ["view", "read", "write", "mfa-enforced"]
+                  enum: ["view", "read", "write"]
                 sharedSecret:
                   type: string
                   description: |

--- a/spec.yaml
+++ b/spec.yaml
@@ -569,12 +569,12 @@ definitions:
                       - `mfa-enforced` requires the user accessing the resource to be
                         MFA-authenticated. This requirement MAY be used if the
                         recipient provider exposes the `enforce-mfa` capability.
-                      - `request-signed` requires the recipient to exchange the given
+                      - `use-code` requires the recipient to exchange the given
                         `code` via a signed HTTPS request to `/token` at the Sending
                         Server, in order to get a short-lived token to be used for
                         subsequent access. This requirement MAY be used if the
                         recipient provider exposes the `receive-code` capability.
-                    enum: ["mfa-enforced", "request-signed"]
+                    enum: ["mfa-enforced", "use-code"]
             webapp:
               type: object
               properties:


### PR DESCRIPTION
This is a draft to extend `requirements` along the concept that "a requirement is an enforced capability that otherwise would be optional".

Proper definition of capabilities is required prior to merge this.