### PR TITLE
Improve share access process and share examples

### DIFF
--- a/spec.yaml
+++ b/spec.yaml
@@ -526,7 +526,7 @@ definitions:
                     or it MAY be absolute, including a hostname. The latter is NOT
                     recommended because of security concerns.
                     In all cases, for a `folder` resource, the composed URI acts
-                    as the root path, such that other files located within MUST
+                    as the root path, such that other files located within SHOULD
                     be accessible by appending their relative path to that URI.
                 sharedSecret:
                   type: string
@@ -573,7 +573,7 @@ definitions:
                     to access the resource, or it MAY be absolute, including a hostname.
                     The latter is NOT recommended because of security concerns.
                     In all cases, for a `folder` resource, the composed URI acts
-                    as the root path, such that other files located within MUST
+                    as the root path, such that other files located within SHOULD
                     be accessible by appending their relative path to that URI.
                 viewMode:
                   type: string
@@ -613,7 +613,7 @@ definitions:
                   description: |
                     An URI to access the resource at the sending server. The URI
                     SHOULD be relative, such as a key or a UUID, in which case the
-                    prefix exposed by the `/.well-known/ocm` endpoint MUST be used
+                    prefix exposed by the `/.well-known/ocm` endpoint SHOULD be used
                     to access the resource, or it MAY be absolute, including
                     a hostname. The latter is NOT recommended because of security
                     concerns.

--- a/spec.yaml
+++ b/spec.yaml
@@ -343,22 +343,22 @@ definitions:
                   type: string
                   description: |
                     The top-level WebDAV path at this endpoint. In order to access
-                    a remote shared resource, implementations MAY use this path
-                    as a prefix, or as the full path (see sharing examples).
+                    a remote shared resource, implementations SHOULD use this path
+                    as a prefix (see sharing examples).
                 webapp:
                   type: string
                   description: |
-                    The top-level path for web apps at this endpoint. This value
-                    is provided for documentation purposes, and it SHALL NOT
-                    be intended as a prefix for share requests.
+                    The top-level path for web apps at this endpoint. In order to
+                    access a remote web app, implementations SHOULD use this path
+                    as a prefix (see sharing examples).
                 datatx:
                   type: string
                   description: |
-                    The top-level path to be used for data transfers. This
-                    value is provided for documentation purposes, and it SHALL
-                    NOT be intended as a prefix. In addition, implementations
-                    are expected to execute the transfer using WebDAV as
-                    the wire protocol.
+                    The top-level path to be used for data transfers. In order to
+                    access a remote shared resource, implementations SHOULD use
+                    this path as a prefix (see sharing examples). In addition,
+                    implementations are expected to execute the transfer using
+                    WebDAV as the wire protocol.
               patternProperties:
                 "^.*$":
                   type: string
@@ -368,7 +368,7 @@ definitions:
                     URI to be used for that protocol.
               example:
                 webdav: "/remote/dav/ocm/"
-                webapp: "/app/ocm/"
+                webapp: "/apps/ocm/"
                 talk: "/apps/spreed/api/"
       capabilities:
         type: array
@@ -517,6 +517,17 @@ definitions:
             webdav:
               type: object
               properties:
+                uri:
+                  type: string
+                  description: |
+                    An URI to access the remote resource. The URI SHOULD be relative,
+                    such as a key or a UUID, in which case the prefix exposed by the
+                    `/.well-known/ocm` endpoint MUST be used to access the resource,
+                    or it MAY be absolute, including a hostname. The latter is NOT
+                    recommended because of security concerns.
+                    In all cases, for a `folder` resource, the composed URI acts
+                    as the root path, such that other files located within MUST
+                    be accessible by appending their relative path to that URI.
                 sharedSecret:
                   type: string
                   description: |
@@ -549,23 +560,21 @@ definitions:
                         MFA-authenticated. This requirement MAY be used if the
                         provider exposes the `mfa-capable` capability.
                     enum: ["mfa-enforced"]
-                uri:
-                  type: string
-                  description: |
-                    An URI to access the remote resource. The URI MAY be relative,
-                    in which case the prefix exposed by the `/.well-known/ocm` endpoint MUST
-                    be used, or it may be absolute (recommended).
             webapp:
               type: object
               properties:
-                uriTemplate:
+                uri:
                   type: string
                   description: |
-                    A templated URI to a client-browsable view of the shared resource,
-                    such that users may use a web application available at the sender site.
-                    If the path includes a `{relative-path-to-shared-resource}` placeholder,
-                    implementations SHOULD replace it with the actual path to ease user
-                    interaction.
+                    An URI to a client-browsable view of the remote resource, such that
+                    users may use a web application available at the sender site.
+                    The URI SHOULD be relative, such as a key or a UUID, in which case
+                    the prefix exposed by the `/.well-known/ocm` endpoint MUST be used
+                    to access the resource, or it MAY be absolute, including a hostname.
+                    The latter is NOT recommended because of security concerns.
+                    In all cases, for a `folder` resource, the composed URI acts
+                    as the root path, such that other files located within MUST
+                    be accessible by appending their relative path to that URI.
                 viewMode:
                   type: string
                   description: |
@@ -602,7 +611,12 @@ definitions:
                 srcUri:
                   type: string
                   description: |
-                    An absolute URI to access the resource at the sending server.
+                    An URI to access the resource at the sending server. The URI
+                    SHOULD be relative, such as a key or a UUID, in which case the
+                    prefix exposed by the `/.well-known/ocm` endpoint MUST be used
+                    to access the resource, or it MAY be absolute, including
+                    a hostname. The latter is NOT recommended because of security
+                    concerns.
                 size:
                   type: integer
                   description: |
@@ -624,24 +638,24 @@ definitions:
           singleProtocolNew:
             name: "multi"
             webdav:
+              uri: "7c084226-d9a1-11e6-bf26-cec0c932ce01"
               sharedSecret: "hfiuhworzwnur98d3wjiwhr"
               permissions: ["read", "write"]
               requirements: ["none"]
-              uri: "https://open-cloud-mesh.org/remote/dav/ocm/7c084226-d9a1-11e6-bf26-cec0c932ce01/path/to/resource.txt"
           multipleProtocols:
             name: "multi"
             webdav:
+              uri: "7c084226-d9a1-11e6-bf26-cec0c932ce01"
               sharedSecret: "hfiuhworzwnur98d3wjiwhr"
               permissions: ["read"]
               requirements: ["mfa-enforced"]
-              uri: "https://open-cloud-mesh.org/remote/dav/ocm/7c084226-d9a1-11e6-bf26-cec0c932ce01/path/to/resource.txt"
             webapp:
+              uri: "7c084226-d9a1-11e6-bf26-cec0c932ce01"
               sharedSecret: "hfiuhworzwnur98d3wjiwhr"
-              uriTemplate: "https://open-cloud-mesh.org/app/ocm/7c084226-d9a1-11e6-bf26-cec0c932ce01/{relative-path-to-shared-resource}"
               viewMode: "read"
             datatx:
+              srcUri: "7c084226-d9a1-11e6-bf26-cec0c932ce01"
               sharedSecret: "hfiuhworzwnur98d3wjiwhr"
-              srcUri: "https://open-cloud-mesh.org/remote/dav/ocm/7c084226-d9a1-11e6-bf26-cec0c932ce01/path/to/resource.txt"
               size: 100000
   NewNotification:
     type: object


### PR DESCRIPTION
This PR is an attempt to fix #157, but in doing so it partly breaks the v1.1 protocol to access a share.

In particular, for the `webdav` and `datatx` protocols compatibility is ensured by keeping the same property name `uri` (resp. `srcUri`), but the recommended value is now a simple identifier or "key", not a full URI.

For the `webapp` protocol I propose to break compatibility, assuming that the only implementation that requires to be adapted is Reva.

This is still work in progress as I'm myself not fully happy, the main outstanding question being shall we actually drop `uri` and go for `sharedKey`?