### PR TITLE
GitHub action for Spec validation

### DIFF
--- a/.github/workflows/oas-validation.yml
+++ b/.github/workflows/oas-validation.yml
@@ -1,3 +1,4 @@
+name: Validate OpenAPI Specification
 on: [push]
 
 jobs:

--- a/.github/workflows/oas-validation.yml
+++ b/.github/workflows/oas-validation.yml
@@ -1,0 +1,14 @@
+on: [push]
+
+jobs:
+  validate_openapi:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate OpenAPI using Swagger CLI
+        uses: mbowman100/swagger-validator-action@2.0
+        with:
+          files: spec.yaml
+

--- a/spec.yaml
+++ b/spec.yaml
@@ -404,12 +404,10 @@ components:
                       this path as a prefix (see sharing examples). In addition,
                       implementations are expected to execute the transfer using
                       WebDAV as the wire protocol.
-                patternProperties:
-                  ^.*$:
+                additionalProperties:
                     type: string
                     description: >
-                      Any additional protocol supported for this resource type
-                      MAY
+                      Any additional protocol supported for this resource type MAY
                       be advertised here, where the value MAY correspond to a top-level
                       URI to be used for that protocol.
                 example:
@@ -718,14 +716,12 @@ components:
                     description: >
                       The size of the file to be transferred from the sending
                       server.
-            patternProperties:
-              ^.*$:
+            additionalProperties:
                 type: object
                 description: >
                   Any optional additional protocols supported for this resource
-                  MAY
-                  be provided here, along with their custom payload. Appropriate
-                  capabilities MUST be advertised in order for a sender to ensure
+                  MAY be provided here, along with their custom payload. Appropriate
+                  capabilities SHOULD be advertised in order for a sender to ensure
                   the recipient can parse such customized payloads.
           example:
             singleProtocolLegacy:

--- a/spec.yaml
+++ b/spec.yaml
@@ -13,15 +13,14 @@ info:
   x-logo:
     url: logo.png
 paths:
-  https://<discovery-fqdn>/.well-known/ocm:
+  /.well-known/ocm:
     get:
       summary: Discovery endpoint
       description: >
         Following RFC 8615, this endpoint returns the properties and
-        capabilities offered by an OCM Server. This endpoint is to be served at
-        the OCM server's FQDN, e.g. as in
-        `https://my-cloud-storage.org/.well-known/ocm`. See [OCM API
-        Discovery](https://github.com/cs3org/OCM-API/blob/develop/IETF-RFC.md#ocm-api-discovery)
+        capabilities offered by an OCM Server. This endpoint MUST be
+        served at the OCM Server's root FQDN, e.g. as in
+        `https://my-cloud-storage.org/.well-known/ocm`. See [OCM API Discovery](https://github.com/cs3org/OCM-API/blob/develop/IETF-RFC.md#ocm-api-discovery)
         for more details.
       responses:
         "200":
@@ -31,12 +30,13 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Discovery"
-  https://<discovery-fqdn>/ocm-provider:
+  /ocm-provider:
     get:
       summary: Legacy discovery endpoint
       description: >
-        This endpoint is a replica of `/.well-known/ocm`. OCM Servers MUST
-        support both.
+        This endpoint is a replica of `/.well-known/ocm`, and MUST be
+        served at the OCM Server's root FQDN as well.
+        OCM Servers MUST support both.
       responses:
         "200":
           description: See `/.well-known/ocm`.

--- a/spec.yaml
+++ b/spec.yaml
@@ -404,10 +404,12 @@ components:
                       this path as a prefix (see sharing examples). In addition,
                       implementations are expected to execute the transfer using
                       WebDAV as the wire protocol.
-                additionalProperties:
+                patternProperties:
+                  ^.*$:
                     type: string
                     description: >
-                      Any additional protocol supported for this resource type MAY
+                      Any additional protocol supported for this resource type
+                      MAY
                       be advertised here, where the value MAY correspond to a top-level
                       URI to be used for that protocol.
                 example:
@@ -716,12 +718,14 @@ components:
                     description: >
                       The size of the file to be transferred from the sending
                       server.
-            additionalProperties:
+            patternProperties:
+              ^.*$:
                 type: object
                 description: >
                   Any optional additional protocols supported for this resource
-                  MAY be provided here, along with their custom payload. Appropriate
-                  capabilities SHOULD be advertised in order for a sender to ensure
+                  MAY
+                  be provided here, along with their custom payload. Appropriate
+                  capabilities MUST be advertised in order for a sender to ensure
                   the recipient can parse such customized payloads.
           example:
             singleProtocolLegacy:


### PR DESCRIPTION
This PR adds an action to validate the spec against the OpenAPI standard.

The validation currently [fails](https://github.com/glpatcern/OCM-API/actions/runs/15361456386/job/43229085223), and we should try and address what does not respect the OpenAPI standard. In particular, it appears that `patternProperties` are not allowed, despite they are advertised as valid.

Edit: the PR was brought to successfully pass the validation, but meanwhile #182 brings additional fixes and will be based on top of this PR.