### PR TITLE
Relax minimum requirements to qualify as OCM Server

### DIFF
--- a/IETF-RFC.md
+++ b/IETF-RFC.md
@@ -240,14 +240,14 @@ The JSON response body offered by the Discoverable Server SHOULD contain the fol
 * REQUIRED: resourceTypes (array) - A list of all resource types this server supports in both the Sending Server role and the Receiving Server role, with their access protocols. Each item in this list should
 itself be an object containing the following fields:
   * name (string) -  A supported resource type (file, folder, calendar, contact, ...).
-                Implementations MUST support `file` at a minimum. Each resource type is identified by its `name`: the list MUST NOT
-          contain more than one resource type object per given `name`.
+                Implementations MUST offer support for at least one resource type, where `file` is the commonly supported one. Each resource type is identified by its `name`:
+                the list MUST NOT contain more than one resource type object per given `name`.
   * shareTypes (array of string) -
                 The supported recipient share types.
                 MUST contain `"user"` at a minimum, plus optionally `"group"` and `"federation"`.
                 Example: `["user"]`
   * protocols (object) - The supported protocols for accessing shared resources of this type.
-                Implementations MUST support at least `webdav` for `file` resources,
+                Implementations that offer `file` resources MUST support at least `webdav`,
                 any other combination of resources and protocols is optional. Example:
                 ```json
                 {


### PR DESCRIPTION
This change is proposed, as discussed today, in the context of OCM implementations for third-party integrations (cf. #180 and #191).

The idea here is that the third-party component is not an EFSS, and may only offer limited support for a given type of resource, NOT including `file`. Yet, it would expose an OCM discovery endpoint and issue Share Creation Notification requests to recipients that possibly host a full-fledged OCM server.