### PR TITLE
Changed definition of public key id to follow Nextcloud

### DIFF
--- a/IETF-RFC.md
+++ b/IETF-RFC.md
@@ -301,7 +301,7 @@ itself be an object containing the following fields:
 * OPTIONAL: publicKey (object) - The signatory used to sign outgoing request to confirm its origin. The 
           signatory is optional, but if present, it MUST contain two string fields, `id` and `publicKeyPem`.
         properties:
-  * REQUIRED id (string) unique id of the key in URI format. The hostname set the origin of the 
+  * REQUIRED keyId (string) unique id of the key in URI format. The hostname set the origin of the 
               request and MUST be identical to the current discovery endpoint.
             Example: https://my-cloud-storage.org/ocm#signature
   * REQUIRED publicKeyPem (string) - PEM-encoded version of the public key.

--- a/spec.yaml
+++ b/spec.yaml
@@ -454,7 +454,7 @@ components:
             The 
             signatory is optional but it MUST contain `id` and `publicKeyPem`.
           properties:
-            id:
+            keyId:
               type: string
               description: >
                 unique id of the key in URI format. The hostname set the origin


### PR DESCRIPTION
While checking the [discovery endpoint at Nextcloud](https://cloud.nextcloud.com/ocm-provider) for other purposes, I realized that they expose the public key id as `keyId`, not just `id`.

Since this is a relatively new entry in the discovery payload, and given that we are not aware of any other implementation that exposes it, I propose to change the standard to reflect the Nextcloud implementation. Yes, we are making a favor to Nextcloud!