### PR TITLE
Clarify and align normative language

### DIFF
--- a/IETF-RFC.md
+++ b/IETF-RFC.md
@@ -44,10 +44,9 @@ Open Cloud Mesh only handles the necessary interactions up to the point where th
 --- middle
 
 # Terms
-The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL
-NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED",  "MAY", and
-"OPTIONAL" in this document are to be interpreted as described in
-RFC 2119.
+The key words "MUST", "MUST NOT", "SHOULD", "SHOULD NOT", and "MAY" in this document are to be interpreted as described in RFC 2119.
+
+The key words "REQUIRED", "RECOMMENDED", "OPTIONAL" has the same meaning as "MUST", "SHOULD" and "MAY" respectively but are used instead of their counterparts where it makes more grammatical sense (such as marking fields in a JSON object).
 
 We define the following concepts (with some non-normative references to related concepts from OAuth and elsewhere):
 
@@ -267,10 +266,10 @@ itself be an object containing the following fields:
                     a remote shared resource, implementations MAY use this path
                     as a prefix, or as the full path (see sharing examples).
     * webapp (string) - The top-level path for web apps at this endpoint. This value
-                    is provided for documentation purposes, and it SHALL NOT
+                    is provided for documentation purposes, and it SHOULD NOT
                     be intended as a prefix for share requests.
     * datatx (string) - The top-level path to be used for data transfers. This
-                    value is provided for documentation purposes, and it SHALL
+                    value is provided for documentation purposes, and it SHOULD
                     NOT be intended as a prefix. In addition, implementations
                     are expected to execute the transfer using WebDAV as
                     the wire protocol.
@@ -481,7 +480,7 @@ make a HTTP POST request
 
 ## Fields
 
-* REQUIRED notificationType (string) - in a Share Acceptance Notification it SHOULD be one of:
+* REQUIRED notificationType (string) - in a Share Acceptance Notification it MUST be one of:
   * 'SHARE_ACCEPTED'
   * 'SHARE_DECLINED'
 * REQUIRED providerId (string) - copied from the Share Creation Notification for the Share this notification is about


### PR DESCRIPTION
# Clarify use of REQUIRED vs RFC 2119 keywords; unify field annotations

This PR addresses specification language consistency as described in [Issue #206](https://github.com/cs3org/OCM-API/issues/206). The goal is to clearly distinguish between **normative keywords** (used for protocol behavior) and **field annotations** (used for JSON schema documentation)

## ✅ Summary of Changes

- 📝 **Terms section clarified**:
  - Added an explicit note explaining that `"REQUIRED"`, `"RECOMMENDED"`, and `"OPTIONAL"` are semantically equivalent to `"MUST"`, `"SHOULD"`, and `"MAY"` but used for readability in JSON object fields.

- 🔄 **Field annotation harmonization**:
  - Updated `"SHOULD be one of"` to `"MUST be one of"` in enumerated values where the value space is normative.

## 📌 Rationale

This change improves:

- Consistency in language use across the specification.
- Clarity for implementers when interpreting the JSON field requirements.



Closes: #206
