### PR TITLE
Proper url spec for ocm server url

### DIFF
--- a/IETF-RFC.md
+++ b/IETF-RFC.md
@@ -1117,8 +1117,7 @@ format:
     * REQUIRED: `url` - an absolute URL identifying the 
     OCM Server. It MUST:
       * include scheme `http://` or `https://`
-      * include host 
-      (either a FQDN or IP address, with an optional PORT)
+      * include host (either a FQDN or an IP address)
       * MAY include a non-default port
       * MUST NOT include a base path (e.g., `/ocm`)
       * MUST NOT include userinfo, query, or fragment

--- a/IETF-RFC.md
+++ b/IETF-RFC.md
@@ -1116,7 +1116,7 @@ format:
   of OCM Servers with the following string fields:
     * REQUIRED: `url` - an absolute URL identifying the 
     OCM Server. It MUST:
-      * include scheme `http://` or `https://`
+      * include scheme: either `https://` or (for testing purposes) `http://`
       * include host (either a FQDN or an IP address)
       * MAY include a non-default port
       * MUST NOT include a base path (e.g., `/ocm`)

--- a/IETF-RFC.md
+++ b/IETF-RFC.md
@@ -1114,7 +1114,14 @@ format:
   Servers exposed by the Directory Service
   * REQUIRED: `servers` - a JSON array of objects to describe the list
   of OCM Servers with the following string fields:
-    * REQUIRED: `url` - the OCM Server's FQDN
+    * REQUIRED: `url` - an absolute URL identifying the 
+    OCM Server. It MUST:
+      * include scheme `http://` or `https://`
+      * include host 
+      (either a FQDN or IP address, with an optional PORT)
+      * MAY include a non-default port
+      * MUST NOT include a base path (e.g., `/ocm`)
+      * MUST NOT include userinfo, query, or fragment
     * REQUIRED: `displayName` - a human-readable name for the OCM Server
   Example:
   ```json
@@ -1122,12 +1129,16 @@ format:
     "federation" : "The ScienceMesh Directory",
     "servers" : [
       {
-       "url" : "https://ocm-server-1.fqdn",
+       "url" : "https://ocm-server-1.example.org",
        "displayName" : "OCM Server 1"
       },
       {
-       "url" : "https://ocm-server-2.fqdn",
+       "url" : "https://ocm-server-2.example.org:4443",
        "displayName" : "OCM Server 2"
+      },
+      {
+       "url" : "http://192.168.1.1:8080",
+       "displayName" : "OCM Server 3"
       }
     ]
   }

--- a/IETF-RFC.md
+++ b/IETF-RFC.md
@@ -1116,12 +1116,14 @@ format:
   of OCM Servers with the following string fields:
     * REQUIRED: `url` - an absolute URL identifying the 
     OCM Server. It MUST:
-      * include scheme: either `https://` or (for testing purposes) `http://`
+      * include scheme: either `https://` or 
+      (for testing purposes) `http://`
       * include host (either a FQDN or an IP address)
       * MAY include a non-default port
       * MUST NOT include a base path (e.g., `/ocm`)
       * MUST NOT include userinfo, query, or fragment
-    * REQUIRED: `displayName` - a human-readable name for the OCM Server
+    * REQUIRED: `displayName` - a human-readable name 
+    for the OCM Server
   Example:
   ```json
   {


### PR DESCRIPTION
I'm intentionally not updating the Discovery endpoint (and any related fields) in this PR. This needs a brief design discussion first. For reference:
```
* REQUIRED: endPoint (string) - The URI of the OCM API available at
this endpoint.  Example: `"https://my-cloud-storage.org/ocm"`
```

Once we reach consensus, I'll submit a follow up patch with the corresponding edits.

This PR is a result of discussion in #244