### PR TITLE
Further fixes and clarifications on the share fields

### DIFF
--- a/IETF-RFC.md
+++ b/IETF-RFC.md
@@ -463,8 +463,8 @@ field of an Invite Acceptance Request.
 
 Step 1: In case it has an OCM Address, it SHOULD first extract `<fqdn>`
 from it (the part after the last `@` sign).
-Step 2: The Discovering Server SHOULD attempt OCM API Discovery a HTTP
-GET request to `https://<fqdn>/.well-known/ocm`.
+Step 2: The Discovering Server SHOULD attempt OCM API Discovery via a
+HTTP GET request to `https://<fqdn>/.well-known/ocm`.
 Step 3: If that results in a valid HTTP response with a valid JSON
 response body within reasonable time, go to step 7.
 Step 4: If not, try a HTTP GET with `https://<fqdn>/ocm-provider` as
@@ -613,10 +613,9 @@ with the fields as described below
 
 * REQUIRED shareWith (string)
           Consumer specific identifier of the user, group or federation
-          the provider wants to share the Resource with.  This is known
-          in advance.  Please note that the consumer service endpoint is
-          known in advance as well, so this is no part of the request
-          body.
+          the provider wants to share the Resource with.  This MUST be
+          known in advance, either via a previous Invitation or through
+          other means.
         Example: "51dc30ddc473d43a6011e9ebba6ca770@geant.org"
 * REQUIRED name (string)
        Name of the Resource (file or folder).
@@ -637,9 +636,7 @@ with the fields as described below
         Example: "6358b71804dfa8ab069cf05ed1b0ed2a@apiwise.nl"
 * REQUIRED sender (string) -
           Provider specific identifier of the user that wants to share
-          the Resource.  Please note that the requesting provider is
-          being identified on a higher level, so the former `remote`
-          property is not part of the request body.
+          the Resource.
         Example: "527bd5b5d689e2c32ae974c6229ff785@apiwise.nl"
 * OPTIONAL ownerDisplayName (string)
           Display name of the owner of the Resource
@@ -649,7 +646,7 @@ with the fields as described below
         Example: "John Doe"
 * REQUIRED shareType (string)
         SHOULD have a value of "user", "group", or "federation", to
-        indicated that the first part of the `shareWith` OCM Address
+        indicate that the first part of the `shareWith` OCM Address
         refers to a Receiving Party who is a single user of the
         Receiving Server, a group of users at the Receiving Servers, or
         a group of users that is spread out over various servers,

--- a/spec.yaml
+++ b/spec.yaml
@@ -490,10 +490,8 @@ components:
           type: string
           description: >
             Consumer specific identifier of the user, group or federation the
-            provider
-            wants to share the resource with. This is known in advance.
-            Please note that the consumer service endpoint is known in advance
-            as well, so this is no part of the request body.
+            provider wants to share the Resource with. This MUST be known
+            in advance, either via a previous Invitation or through other means.
           example: 51dc30ddc473d43a6011e9ebba6ca770@geant.org
         name:
           type: string
@@ -509,9 +507,8 @@ components:
           type: string
           description: >
             Identifier to identify the shared resource at the provider side.
-            This is
-            unique per provider such that if the same resource is shared twice,
-            this providerId will not be repeated.
+            This is unique per provider such that if the same resource is shared
+            twice, this providerId will not be repeated.
           example: 7c084226-d9a1-11e6-bf26-cec0c932ce01
         owner:
           description: |
@@ -521,9 +518,7 @@ components:
         sender:
           description: |
             Provider specific identifier of the user that wants to share the
-            resource. Please note that the requesting provider is being
-            identified on a higher level, so the former `remote` property
-            is not part of the request body.
+            resource.
           type: string
           example: 527bd5b5d689e2c32ae974c6229ff785@apiwise.nl
         ownerDisplayName:


### PR DESCRIPTION
Following #244, I realized that the text describing the share fields had some residual references from past edits, which make no sense any longer. This is to fix them.