### PR TITLE
add: CI for GitHub pages

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -1,0 +1,42 @@
+name: Deploy GitHub Pages
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build site
+        run: |
+          rm -rf dist
+          mkdir -p dist
+          cp ./docs.html ./dist/index.html
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    needs: build
+
+    # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
+    permissions:
+      pages: write      # to deploy to Pages
+      id-token: write   # to verify the deployment originates from an appropriate source
+
+    # Deploy to the github-pages environment
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    # Specify runner + deployment step
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+


### PR DESCRIPTION
Based on Michiels implementation of `docs.html` we don't even need to build GitHub pages on `spec.yaml` changes since the script inside the page would fetch latest spec.

```html
<script>
      const params = new URLSearchParams(window.location.search);
      const user = params.get('user');
      const repo = params.get('repo');
      const branch = params.get('branch');
      let changed = false;
      if (user === null) {
        params.set('user', 'cs3org');
        changed = true;
      }
      if (repo === null) {
        params.set('repo', 'OCM-API');
        changed = true;
      }
      if (branch === null) {
        params.set('branch', 'develop');
        changed = true;
      }
      if (changed) {
        params.sort();
        window.location = `?${params.toString()}`;
      }
      document.querySelector('redoc').setAttribute('spec-url', `https://raw.githubusercontent.com/${user}/${repo}/${branch}/spec.yaml`);
    </script>
```