### PR TITLE
fix: group is meant for the users on a singular server

### DIFF
--- a/IETF-RFC.md
+++ b/IETF-RFC.md
@@ -672,7 +672,7 @@ To create a Share, the Sending Server SHOULD make a HTTP POST request
   SHOULD have a value of "user", "group", or "federation", to
   indicate that the first part of the `shareWith` OCM Address
   refers to a Receiving Party who is a single user of the
-  Receiving Server, a group of users at the Receiving Servers, or
+  Receiving Server, a group of users at the Receiving Server, or
   a group of users that is spread out over various servers,
   including at least one user at the Receiving Server.
 * REQUIRED resourceType (string)


### PR DESCRIPTION
PR for fixing a typo pointed out this discussion: https://github.com/cs3org/OCM-API/issues/270#issuecomment-3219699828
