### PR TITLE
Fix: explicitly state the uniqueness of providerIds

### DIFF
--- a/IETF-RFC.md
+++ b/IETF-RFC.md
@@ -649,10 +649,9 @@ To create a Share, the Sending Server SHOULD make a HTTP POST request
   Example: "This is the Open API Specification file (in YAML
   format) of the Open Cloud Mesh API."
 * REQUIRED providerId (string)
-  Identifier to identify the Shared Resource at the provider
-  side.  This is unique per provider such that if the same
-  Resource is shared twice, this providerId will not be
-  repeated.
+  Opaque value to identify the Shared Resource at the provider side.
+  This MUST be unique per Resource and per share, such that multiple
+  shares of a given Resource are guaranteed to get different values.
   Example: 7c084226-d9a1-11e6-bf26-cec0c932ce01
 * REQUIRED owner (string) -
   OCM Address of the user who owns the

--- a/spec.yaml
+++ b/spec.yaml
@@ -506,9 +506,9 @@ components:
         providerId:
           type: string
           description: >
-            Identifier to identify the shared resource at the provider side.
-            This is unique per provider such that if the same resource is shared
-            twice, this providerId will not be repeated.
+            Opaque value to identify the Shared Resource at the provider side.
+            This MUST be unique per Resource and per share, such that multiple
+            shares of a given Resource are guaranteed to get different values.
           example: 7c084226-d9a1-11e6-bf26-cec0c932ce01
         owner:
           description: |


### PR DESCRIPTION
This fixes #271 with an explicit sentence about the uniqueness of `providerId` values in Share Creation Notification payloads.