### PR TITLE
Require http-sig for Directory Service response

### DIFF
--- a/IETF-RFC.md
+++ b/IETF-RFC.md
@@ -1294,6 +1294,9 @@ format:
 }
 ```
 
+A Directory Service MUST sign its responses using httpsig [RFC9421], so
+clients can verify the authenticity of the response.
+
 # Acknowledgements
 
 Our deepest thanks and appreciation go to the people who started the


### PR DESCRIPTION
This should be a requirement IMO because a lot of trust can be derived from a federation if we trust the directory service.