### PR TITLE
Simplified token exchange and related requirements

### DIFF
--- a/IETF-RFC.md
+++ b/IETF-RFC.md
@@ -636,7 +636,7 @@ contain the following information about its OCM API:
   As implementations MUST accept Share Creation Notifications
   to be compliant, it is not necessary to expose that as a
   capability.
-  Example: `["receive-code", "webdav-uri"]`.  The array MAY
+  Example: `["exchange-token", "webdav-uri"]`.  The array MAY
   include for instance:
   _ `"enforce-mfa"` - to indicate that this OCM Server can apply a
   Sending Server's MFA requirements for a Share on their behalf.
@@ -651,29 +651,29 @@ contain the following information about its OCM API:
   Invite Sender or Invite Receiver OCM Server.  This might be useful
   for suggesting to a user that existing contacts might be upgraded
   to the more secure (and possibly required) invite flow.
-  _ `"receive-code"` - to indicate that this OCM Server can receive a
-  `code` as part of a Share Creation Notification, and exchange it
-  for a bearer token at the Sending Server's tokenEndPoint.
+  _ `"exchange-token"` - to indicate that this OCM Server exposes a
+  [RFC6749]-compliant endpoint, which allows to exchange a secret
+  received in the protocol properties of a Share Creation Notification
+  for a short-lived bearer token.
   _ `"invite-wayf"` - to indicate that this OCM Server exposes a WAYF
   Page to facilitate the Invite flow.
 * OPTIONAL: criteria (array of string) - The criteria for accepting a
   Share Creation Notification.
   As all Receiving Servers SHOULD require the use of TLS in API
   calls, it is not necessary to expose that as a criterium.
-  Example: `["http-request-signatures", "code"]`.  The array MAY
-  include for instance:
+  Example: `["http-request-signatures"]`.  The array MAY include
+  for instance:
   _ `"http-request-signatures"` - to indicate that API requests
   without http signatures will be rejected.
-  _ `"code"` - to indicate that API requests without code will be
-  rejected (i.e.  the `sharedSecret` in the protocol details will be
-  ignored).
+  _ `"token-exchange"` - to indicate that API requests without
+  token exchange will be rejected (see the [Code Flow](#code-flow)
+  section).
   _ `"denylist"` - some servers MAY be blocked based on their IP
   address
   _ `"allowlist"` - unknown servers MAY be blocked based on their IP
   address \* `"invite"` - an invite MUST have been exchanged between the
   sender and the receiver before a Share Creation Notification can be
   sent
-
 * OPTIONAL: publicKey (object) - The signatory used to sign outgoing
   request to confirm its origin.
    The signatory is optional, but if present, it MUST contain
@@ -697,7 +697,7 @@ contain the following information about its OCM API:
 `/index.php/apps/sciencemesh/accept?token=zi5kooKu3ivohr9a&providerDomain=example.com`.
 * OPTIONAL: tokenEndPoint (string) - URL of the token endpoint where
   the Sending Server can exchange a `code` for a bearer token.
-  Implementations that offer the `"receive-code"` capability MUST
+  Implementations that offer the `"exchange-token"` capability MUST
   provide this URL as well.
   Example: `"https://my-cloud-storage.org/ocm/token"`.
 
@@ -770,9 +770,6 @@ To create a Share, the Sending Server SHOULD make a HTTP POST request
   The expiration time for the OCM share, in seconds
   of UTC time since Unix epoch.  If omitted, it is assumed
   that the share does not expire.
-* OPTIONAL code (string)
-  A nonce to be exchanged for a (potentially short-lived)
-  bearer token at the Sending Server's tokenEndPoint [RFC6749]
 * REQUIRED protocol (object)
   JSON object with specific options for each protocol.
   The supported protocols are: - `webdav`, to access the data -
@@ -817,12 +814,10 @@ servers MAY only support `webdav`.
     SHOULD be relative, in which case the prefix
     exposed by the `/.well-known/ocm` endpoint MUST
     be used.  Absolute URIs are deprecated.
-  - OPTIONAL sharedSecret (string) - REQUIRED if no `code` field is
-    given for the Share as a whole (see above).  An
-    optional secret to be used to access the Resource,
-    such as a bearer token.
-    To prevent leaking it in logs it MUST NOT appear in
-    any URI.
+  - REQUIRED sharedSecret (string)
+    A secret to be used to access the Resource, such as
+    a bearer token.  To prevent leaking it in logs it
+    MUST NOT appear in any URI.
   - OPTIONAL permissions (array of strings) -
     The permissions granted to the sharee.  A subset
     of: - `read` allows read-only access including
@@ -831,13 +826,14 @@ servers MAY only support `webdav`.
     Resource.
   - OPTIONAL requirements (array of strings) -
     The requirements that the sharee MUST fulfill to
-    access the Resource.  A subset of: - `mfa-enforced` requires the
+    access the Resource.  A subset of: - `must-use-mfa` requires the
     consumer to be MFA-authenticated.  This MAY be used if the
     recipient provider exposes the `enforce-mfa`
-    capability.  - `use-code` requires the consumer to exchange
-    the given `code` via a signed HTTPS request.  This
-    MAY be used if the recipient provider exposes the
-    `receive-code` capability.
+    capability.  - `must-exchange-token` requires the recipient to
+    exchange the given `sharedSecret` via a signed HTTPS request
+    to the Sending Server's {tokenEndPoint} [RFC6749].
+    This MAY be used if the recipient provider exposes the
+    `exchange-token` capability.
 * Protocol details for `webapp` MAY contain:
   - REQUIRED uri (string)
     A URI to a client-browsable view of the Shared

--- a/IETF-RFC.md
+++ b/IETF-RFC.md
@@ -695,8 +695,8 @@ contain the following information about its OCM API:
   `"/index.php/apps/sciencemesh/accept"` is specified here then a WAYF
   Page SHOULD redirect the end-user to
 `/index.php/apps/sciencemesh/accept?token=zi5kooKu3ivohr9a&providerDomain=example.com`.
-* OPTIONAL: tokenEndPoint (string) - URL of the token endpoint where
-  the Sending Server can exchange a `code` for a bearer token.
+* OPTIONAL: tokenEndPoint (string) - URL of the token endpoint where the
+  Sending Server can exchange a secret for a short-lived bearer token.
   Implementations that offer the `"exchange-token"` capability MUST
   provide this URL as well.
   Example: `"https://my-cloud-storage.org/ocm/token"`.
@@ -961,48 +961,52 @@ notification that this happened.
 # Resource Access
 
 To access the Resource, the Receiving Server MAY use multiple ways,
-depending on the body of the Share Creation Notification.  The procedure
-is as follows:
+depending on the body of the Share Creation Notification and the
+protocol required for access.  The procedure is as follows:
 
 1.  The receiver MUST extract the OCM Server FQDN from the `sender`
     field of the received share, and MUST query the
-    [Discovery](#ocm-api-discovery) endpoint at that address: the
-    `resourceTypes[0].protocols.webdav` value is the
-    `<sender-ocm-path>` to be used in step 3.
-2.  If `code` is not empty, the receiver SHOULD make a signed POST
-    request to the path in the Sending Server’s tokenEndPoint, to
-    exchange the code for a short-lived bearer token, and then use that
-    bearer token to access the Resource (See the [Code Flow](
-    #code-flow) section).
-3.  If `protocol.name` = `webdav`, the receiver SHOULD inspect the
-    `protocol.options` property.  If it contains a `sharedSecret`, as in
-    the [legacy example](
-https://cs3org.github.io/OCM-API/docs.html?branch=develop&repo=OCM-API&user=cs3org#/paths/~1shares/post),
-    then the receiver SHOULD make a HTTP PROPFIND request to
-    `https://<sharedSecret>:@<sender-host><sender-ocm-path>`.  Note that
-    this access method, based on Basic Auth, is _deprecated_ and may be
-    removed in a future release of the Protocol.
-4.  Otherwise, if `protocol.name` = `multi`, the receiver MUST inspect
-    the `protocol.webdav.uri` property: if it's a complete URI, the
-    receiver MUST make a HTTP PROPFIND request against it to access the
-    Remote Resource.  If it only contains an identifier `<key>`, the
-    receiver MUST make a HTTP PROPFIND request to
-    `https://<sender-host><sender-ocm-path>/<key>` in order to access
-    the Remote Resource.  Additionally, the receiver MUST pass an
-    `Authorization: bearer` header with either the short-lived bearer
-    token obtained in step 2, if applicable, or the
-    `protocol.webdav.sharedSecret` value.
+    [Discovery](#ocm-api-discovery) endpoint at that address: let
+    `<sender-ocm-path>` be the `resourceTypes[0].protocols.webdav` value
+    to be used later, if defined.
+2.  If `protocol.name` is `multi`, the receiver MUST inspect the
+    `protocol.{protocolName}` properties corresponding to the protocol
+    of concern, and act according to its semantics.  For the specific
+    case where `protocol.webdav` is available and the receiver wants
+    to use it, the following steps are to be followed.
+3.  The `protocol.webdav.requirements` MUST be inspected:
+3.1. If it includes `must-exchange-token`, the receiver MUST make a
+     signed POST request to the path in the Sending Server’s
+     {tokenEndPoint}, to exchange the `protocol.webdav.sharedSecret`
+     token for a short-lived bearer token, and then use that bearer
+     token to access the Resource (See the [Code Flow](#code-flow)
+     section).
+3.2. If it includes `must-use-mfa`, the Receiving Server MUST ensure
+     that the Receiving Party has been authenticated with MFA, or prompt
+     the consumer in order to elevate their session, if applicable.
+4. The `protocol.webdav.uri` property MUST now be inspected: if it's a
+   complete URI, the receiver MUST make a HTTP PROPFIND request against
+   it to access the Remote Resource, otherwise it is to be taken as an
+   identifier `<id>`, in which case the receiver MUST make a HTTP
+   PROPFIND request to: `https://<sender-host><sender-ocm-path>/<id>`
+   in order to access to the Remote Resource.  The receiver MUST pass
+   an `Authorization: bearer` header with either the short-lived bearer
+   token obtained in step 3.1., if applicable, or the
+   `protocol.webdav.sharedSecret` value.
+5. Otherwise, if `protocol.name` is `webdav` the receiver SHOULD inspect
+   the `protocol.options` property: if `protocol.options.sharedSecret`
+   is defined, then the receiver SHOULD make a HTTP PROPFIND request to
+   `https://<sharedSecret>:@<sender-host><sender-ocm-path>`.  Note that
+   this access method, based on Basic Auth, is _deprecated_ and may be
+   removed in a future release of the Protocol.  If a secret cannot be
+   identified (e.g. because `protocol.options` is undefined), then
+   the receiver SHOULD discard the share as invalid.
 
 In all cases, in case the Shared Resource is a folder and the Receiving
 Server accesses a Resource within that shared folder, it SHOULD append
 its relative path to that URL.  In other words, the Sending Server
 SHOULD support requests to URLs such as
 `https://<sender-host><sender-ocm-path>/path/to/resource.txt`.
-
-Additionally, if `protocol.<protocolname>.requirements` includes
-`mfa-enforced`, the Receiving Server MUST ensure that the Receiving
-Party has been authenticated with MFA, or prompt the consumer in order
-to elevate their session, if applicable.
 
 
 # Code Flow
@@ -1017,7 +1021,7 @@ No user interaction or redirect is involved. [RFC6749]
 ##  Token Request
 
 To obtain an access token, the Receiving Server MUST send an HTTP POST
-request to the Sending Server’s tokenEndPoint as discovered in the
+request to the Sending Server’s {tokenEndPoint} as discovered in the
 OCM provider metadata, following section 4.4.2 of [RFC6749].  Here
 follows an example of such POST request:
 
@@ -1043,7 +1047,7 @@ code=my_secret_code
 The request MUST be signed using an HTTP Message Signature
 [RFC9421].  The `client_id` identifies the Receiving Server and MUST be
 set to its fully qualified domain name.  The `code` parameter carries
-the authorization code that was issued by the Sending Server in the
+the authorization secret that was issued by the Sending Server in the
 Share Creation Notification.  It is allowed to send the additional
 parameters defined in [RFC6749] for the `authorization_code` grant type,
 but they MUST be ignored.
@@ -1067,7 +1071,7 @@ structure visible to the Receiving Server.  The token authorizes the
 Receiving Server to access the shared resource using the appropriate
 transport protocol (e.g., WebDAV).  The `expires_in` value indicates
 the token lifetime in seconds.  No `refresh_token` is issued, instead
-the same request to the tokenEndPoint MUST be repeated before the
+the same request to the {tokenEndPoint} MUST be repeated before the
 `access_token` has expired, to recieve a new `access_token` that can
 then be used in the same manner.
 

--- a/spec.yaml
+++ b/spec.yaml
@@ -18,7 +18,7 @@ paths:
     get:
       summary: Discovery endpoint
       description: >
-        Following RFC 8615, this endpoint returns the properties and
+        Following [RFC8615], this endpoint returns the properties and
         capabilities offered by an OCM Server. This endpoint MUST be
         served at the OCM Server's root FQDN, e.g. as in
         `https://my-cloud-storage.org/.well-known/ocm`. See [OCM API Discovery](https://github.com/cs3org/OCM-API/blob/develop/IETF-RFC.md#ocm-api-discovery)
@@ -108,9 +108,9 @@ paths:
             Retry-After:
               description: >
                 Indication for the client when the service could be requested
-                again in HTTP Date format as used by the  Internet Message
+                again in HTTP Date format as used by the Internet Message
                 Format [RFC5322] (e.g. `Wed, 21 Oct 2015 07:28:00 GMT`) or the
-                number of seconds  (e.g. 3000 if you the service is expected to
+                number of seconds (e.g. 3000 if you the service is expected to
                 be available again within 50 minutes).
               schema:
                 type: string
@@ -424,7 +424,7 @@ components:
               - webdav-uri
               - protocol-object
               - invites
-              - receive-code
+              - exchange-token
           example:
             - webdav-uri
             - protocol-object
@@ -438,7 +438,7 @@ components:
             type: string
             enum:
               - http-request-signatures
-              - code
+              - token-exchange
               - denylist
               - allowlist
               - invite
@@ -471,7 +471,7 @@ components:
           type: string
           description: >
             Optional URL path of the Token Exchange endpoint to obtain bearer tokens in exchange for codes.
-            If the `receive-code` capability is exposed, the tokenEndPoint MUST be advertised in the discovery response.
+            If the `exchange-token` capability is exposed, the tokenEndPoint MUST be advertised in the discovery response.
           example: /index.php/apps/sciencemesh/token
         inviteAcceptDialog:
           type: string
@@ -557,11 +557,6 @@ components:
           description: >
             The expiration time for the share, in seconds of UTC time since
             Unix epoch. If omitted, it is assumed that the share does not expire.
-        code:
-          type: string
-          description: |
-            A nonce to be exchanged for a (potentially short-lived) bearer token
-            at the Sending Server's {tokenEndPoint}.
         protocol:
           type: object
           description: |
@@ -611,11 +606,8 @@ components:
                 sharedSecret:
                   type: string
                   description: >
-                    An optional secret to be used to access the resource, such
-                    as a bearer token. If a `code` is provided, it SHOULD be used
-                    instead via the code flow interaction, and the `sharedSecret`
-                    SHOULD be omitted. To prevent leaking it in logs it MUST NOT
-                    appear in any URI.
+                    A secret to be used to access the resource, such as a bearer token.
+                    To prevent leaking it in logs it MUST NOT appear in any URI.
                 permissions:
                   type: array
                   items:
@@ -640,17 +632,17 @@ components:
                       present it MUST NOT be empty. A recipient provider MUST reject
                       a share whose requirements it does not understand.
                       The following requirements are currently supported:
-                      - `mfa-enforced` requires the user accessing the resource to be
+                      - `must-use-mfa` requires the user accessing the resource to be
                         MFA-authenticated. This requirement MAY be used if the
                         recipient provider exposes the `enforce-mfa` capability.
-                      - `use-code` requires the recipient to exchange the given
-                        `code` via a signed HTTPS request to {tokenEndPoint} at the
+                      - `must-exchange-token` requires the recipient to exchange the given
+                        `sharedSecret` via a signed HTTPS request to tokenEndPoint at the
                         Sending Server, in order to get a short-lived token to be used
-                        for subsequent access. This requirement MAY be used if the
-                        recipient provider exposes the `receive-code` capability.
+                        for subsequent access [RFC6749]. This requirement MAY be used if
+                        the recipient provider exposes the `exchange-token` capability.
                     enum:
-                      - mfa-enforced
-                      - use-code
+                      - must-use-mfa
+                      - must-exchange-token
             webapp:
               type: object
               properties:

--- a/spec.yaml
+++ b/spec.yaml
@@ -235,7 +235,7 @@ paths:
     post:
       summary: Token Exchange endpoint
       description: >
-        This optional endpoint allows to obtain a (potentially short-lived) bearer token in exchange for a code.
+        This optional endpoint allows to obtain a (potentially short-lived) bearer token in exchange for a secret.
         See [Resource Access](https://github.com/cs3org/OCM-API/blob/develop/IETF-RFC.md#resource-access)
         for more details. The actual endpoint URL is discovered via OCM provider metadata
         (tokenEndPoint).
@@ -372,30 +372,26 @@ components:
               protocols:
                 type: object
                 description: >
-                  The supported protocols to access shared resources at this
-                  endpoint.
+                  The supported protocols to access shared resources at this endpoint.
                   Implementations MUST support at least `webdav` for `file` resources,
                   any other combination of resources and protocols is optional.
                 properties:
                   webdav:
                     type: string
                     description: >
-                      The top-level WebDAV path at this endpoint. In order to
-                      access
+                      The top-level WebDAV path at this endpoint. In order to access
                       a remote shared resource, implementations SHOULD use this path
                       as a prefix (see sharing examples).
                   webapp:
                     type: string
                     description: >
-                      The top-level path for web apps at this endpoint. In order
-                      to
+                      The top-level path for web apps at this endpoint. In order to
                       access a remote web app, implementations SHOULD use this path
                       as a prefix (see sharing examples).
                   datatx:
                     type: string
                     description: >
-                      The top-level path to be used for data transfers. In order
-                      to
+                      The top-level path to be used for data transfers. In order to
                       access a remote shared resource, implementations SHOULD use
                       this path as a prefix (see sharing examples). In addition,
                       implementations are expected to execute the transfer using
@@ -403,8 +399,7 @@ components:
                 additionalProperties:
                     type: string
                     description: >
-                      Any additional protocol supported for this resource type
-                      MAY
+                      Any additional protocol supported for this resource type MAY
                       be advertised here, where the value MAY correspond to a top-level
                       URI to be used for that protocol.
                 example:
@@ -673,13 +668,10 @@ components:
                   type: string
                   description: >
                     An optional secret to be used to access the remote web app, such as
-                    a bearer token. To prevent leaking it in logs it MUST NOT appear
-                    in any URI. If a `code` is provided, then the sending host MUST
-                    accept the short-lived bearer token when serving the web app,
-                    which can be exchanged in the code flow interaction. The exchange
-                    MAY already have happened if the recipient accessed the underlying
-                    resource via WebDAV, in a multi-protocol scenario. In this case,
-                    the `sharedSecret` SHOULD be omitted.
+                    a bearer token.  To prevent leaking it in logs it MUST NOT appear
+                    in any URI.  In a multi-protocol share scenario with WebDAV, the
+                    access requirements provided in the `webdav` part MUST apply for
+                    `webapp` accesses as well.
             datatx:
               type: object
               properties:
@@ -687,10 +679,10 @@ components:
                   type: string
                   description: >
                     An optional secret to be used to access the resource, such as
-                    a bearer token. If a `code` is provided, it SHOULD be used
-                    instead via the code flow interaction, and the `sharedSecret`
-                    SHOULD be omitted. To prevent leaking it in logs it MUST NOT
-                    appear in any URI.
+                    a bearer token.  To prevent leaking it in logs it MUST NOT
+                    appear in any URI.  In a multi-protocol share scenario with WebDAV,
+                    the access requirements provided in the `webdav` part MUST apply
+                    for `datatx` transfers as well.
                 srcUri:
                   type: string
                   description: >
@@ -853,7 +845,7 @@ components:
           example: receiver.org
         code:
           type: string
-          description: Code received in the Share Creation Notification
+          description: Secret received in the Share Creation Notification
           example: xyz
         grant_type:
           type: string


### PR DESCRIPTION
This is an attempt to simplify the semantic of the "Code flow", and implements #294.

Notable changes:
* the `receive-code` capability was renamed to `exchange-token`
* the `code` criteria was renamed to `token-exchange`
* the `mfa-enforced` requirement was renamed to `must-use-mfa`
* the `use-code` requirement was renamed to `must-exchange-token`

I believe none of those breaking changes are problematic as to the best of our knowledge there's no implementation yet of the Code flow.