### PR TITLE
Make recipientPublicKey plural

### DIFF
--- a/IETF-RFC.md
+++ b/IETF-RFC.md
@@ -905,7 +905,7 @@ A 201 response status means the Share Creation Notification Request was
 successful.  In this case, the response body MUST contain a JSON
 document representing an object with the following string fields:
   - REQUIRED: `recipientDisplayName` - the Recipient's display name.
-  - OPTIONAL: `recipientPublicKey` - the Recipient's public key.
+  - OPTIONAL: `recipientPublicKeys` - the Recipient's public key(s).
     This property MUST be returned when the protocol of the incoming
     share was `ssh`.
 A 400 response status means some parameters were invalid or missing.

--- a/spec.yaml
+++ b/spec.yaml
@@ -75,10 +75,12 @@ paths:
                     description: >
                       Display name of the recipient
                     example: John Doe
-                  recipientPublicKey:
-                    type: string
+                  recipientPublicKeys:
+                    type: array
+                    items:
+                      type: string
                     description: >
-                      The public key of the recipient. This value MUST be provided
+                      The public key(s) of the recipient. This value MUST be provided
                       in case the Share Creation Notification includes the `ssh` protocol.
         "400":
           description: >


### PR DESCRIPTION
I order for server-to-server interactions to work over ssh, the recipient OCM server needs to have a private key, that can be used for access, and an implementation may ask the user to upload a key pair for this purpose, or generate one on behalf of the user.

However a user may also want to access the share directly using other means, or an enterprise may want to enable third-party-copy and for this reason it will be useful to be able to reply with multiple public keys, used for different purposes.