### PR TITLE
Add `ssh` to supported protocols

### DIFF
--- a/spec.yaml
+++ b/spec.yaml
@@ -591,8 +591,9 @@ components:
           description: |
             JSON object with specific options for each protocol.
             The supported protocols are:
-            - `webdav`, to access the data
+            - `webdav`, to access the data via WebDAV
             - `webapp`, to access remote web applications
+            - `ssh`, to access the data via SFTP/SCP
             Other custom protocols might be added in the future.
           required:
             - name


### PR DESCRIPTION
Minor spec bug, where ssh was missing from supported protocols