### PR TITLE
Fix: accessType should be plural as it is an array

### DIFF
--- a/IETF-RFC.md
+++ b/IETF-RFC.md
@@ -822,7 +822,7 @@ To create a Share, the Sending Server SHOULD make a HTTP POST request
   servers MAY support both `webdav` and `multi`, but v1.0
   servers MAY only support `webdav`.
 * Protocol details for `webdav` MAY contain:
-  - OPTIONAL accessType (array of strings) - The type of access
+  - OPTIONAL accessTypes (array of strings) - The type of access
     being granted to the remote resource.  If omitted, it defaults to
     `['remote']`.  A subset of: - `remote` signals the recipient that
     the resource is available for remote access and interactive
@@ -878,7 +878,7 @@ To create a Share, the Sending Server SHOULD make a HTTP POST request
     An optional secret to be used to access the remote
     web app, for example in the form of a bearer token.
 * Protocol details for `ssh` MAY contain:
-  - OPTIONAL accessType (array of strings) - The type of access
+  - OPTIONAL accessTypes (array of strings) - The type of access
     being granted to the remote resource.  If omitted, it defaults to
     `['remote']`.  A subset of: - `remote` signals the recipient that
     the resource is available for remote access, e.g. via sshfs.

--- a/spec.yaml
+++ b/spec.yaml
@@ -625,7 +625,7 @@ components:
                 - uri
                 - permissions
               properties:
-                accessType:
+                accessTypes:
                   type: array
                   description: >
                     The type of access being granted to the remote resource.
@@ -731,7 +731,7 @@ components:
             ssh:
               type: object
               properties:
-                accessType:
+                accessTypes:
                   type: array
                   description: >
                     The type of access being granted to the remote resource.
@@ -776,7 +776,7 @@ components:
             multipleProtocols:
               name: multi
               webdav:
-                accessType: ['remote', 'datatx']
+                accessTypes: ['remote', 'datatx']
                 uri: 7c084226-d9a1-11e6-bf26-cec0c932ce01
                 sharedSecret: hfiuhworzwnur98d3wjiwhr
                 permissions:
@@ -788,7 +788,7 @@ components:
                 sharedSecret: hfiuhworzwnur98d3wjiwhr
                 viewMode: read
               ssh:
-                accessType: ['datatx']
+                accessTypes: ['datatx']
                 uri: extuser@my-cloud-storage.org:/7c084226-d9a1-11e6-bf26-cec0c932ce01
     NewNotification:
       type: object


### PR DESCRIPTION
This PR fixes the newly-introduced `accessType` field to be spelled similarly to other properties such as `permissions`.