### PR TITLE
Improve resource access description with token exchange

### DIFF
--- a/IETF-RFC.md
+++ b/IETF-RFC.md
@@ -1110,13 +1110,17 @@ protocol required for access.  The procedure is as follows:
 3.1. If it includes `must-exchange-token`, the receiver MUST make a
      signed POST request to the path in the Sending Server’s
      {tokenEndPoint}, to exchange the `protocol.webdav.sharedSecret`
-     token for a short-lived bearer token, and then use that bearer
+     token for a short-lived bearer token, and only use that bearer
      token to access the Resource (See the [Code Flow](#code-flow)
-     section).
+     section).  If the `must-exchange-token` requirement is not present
+     and the Discovery endpoint inspected at step 1. exposes the
+     `token-exchange` capability, the receiver MAY attempt to perform
+     the token exchange as above, but it MUST fall back to the following
+     steps should the process fail.
 3.2. If it includes `must-use-mfa`, the Receiving Server MUST ensure
      that the Receiving Party has been authenticated with MFA, or prompt
      the consumer in order to elevate their session, if applicable.
-4. The `protocol.webdav.uri` property MUST now be inspected: if it's a
+5. The `protocol.webdav.uri` property MUST now be inspected: if it's a
    complete URI, the receiver MUST make a HTTP PROPFIND request against
    it to access the Remote Resource, otherwise it is to be taken as an
    identifier `<id>`, in which case the receiver MUST make a HTTP
@@ -1125,7 +1129,7 @@ protocol required for access.  The procedure is as follows:
    an `Authorization: bearer` header with either the short-lived bearer
    token obtained in step 3.1., if applicable, or the
    `protocol.webdav.sharedSecret` value.
-5. Otherwise, if `protocol.name` is `webdav` the receiver SHOULD inspect
+6. Otherwise, if `protocol.name` is `webdav` the receiver SHOULD inspect
    the `protocol.options` property: if `protocol.options.sharedSecret`
    is defined, then the receiver SHOULD make a HTTP PROPFIND request to
    `https://<sharedSecret>:@<sender-host><sender-ocm-path>`.  Note that

--- a/IETF-RFC.md
+++ b/IETF-RFC.md
@@ -1120,7 +1120,7 @@ protocol required for access.  The procedure is as follows:
 3.2. If it includes `must-use-mfa`, the Receiving Server MUST ensure
      that the Receiving Party has been authenticated with MFA, or prompt
      the consumer in order to elevate their session, if applicable.
-5. The `protocol.webdav.uri` property MUST now be inspected: if it's a
+4. The `protocol.webdav.uri` property MUST now be inspected: if it's a
    complete URI, the receiver MUST make a HTTP PROPFIND request against
    it to access the Remote Resource, otherwise it is to be taken as an
    identifier `<id>`, in which case the receiver MUST make a HTTP
@@ -1129,7 +1129,7 @@ protocol required for access.  The procedure is as follows:
    an `Authorization: bearer` header with either the short-lived bearer
    token obtained in step 3.1., if applicable, or the
    `protocol.webdav.sharedSecret` value.
-6. Otherwise, if `protocol.name` is `webdav` the receiver SHOULD inspect
+5. Otherwise, if `protocol.name` is `webdav` the receiver SHOULD inspect
    the `protocol.options` property: if `protocol.options.sharedSecret`
    is defined, then the receiver SHOULD make a HTTP PROPFIND request to
    `https://<sharedSecret>:@<sender-host><sender-ocm-path>`.  Note that


### PR DESCRIPTION
Following the implementation of the code flow in Nextcloud as part of https://github.com/cs3org/OCM-STA/issues/6, we discussed to recommend in the spec that the token exchange flow MAY be performed even in the absence of a requirement, in case the remote endpoint offers the `token-exchange` capability.

This PR specifies this, implying that in such a case a fall-back must be implemented to normal bearer-token (or basic auth) access, should the token exchange fail.

cc @enriquepablo @mickenordin 