### PR TITLE
Clarify copyright status of specification for DFSG compatibility

### DIFF
--- a/IETF-RFC.md
+++ b/IETF-RFC.md
@@ -1352,6 +1352,14 @@ signed using HTTP Signatures.  Bearer tokens MUST be treated as
 confidential and never logged, persisted beyond their lifetime, or
 transmitted over unsecured channels.
 
+# Copying conditions
+
+The author(s) agree to grant third parties the irrevocable right to
+copy, use and distribute the work, with or without modification, in
+any medium, without royalty, provided that, unless separate permission
+is granted, redistributed modified works do not contain misleading
+author, version, name of work, or endorsement information.
+
 # References
 
 ## Normative References


### PR DESCRIPTION
Adding new section "Copying condition" lifted from <URL: https://wiki.debian.org/NonFreeIETFDocuments > to ensure the specification text follow the Debian Free Software Guidelines and can be distributed as part of programs in Debian outside the non-free set.