### PR TITLE
Revamped and enhanced webapp protocol in I-D and spec.yaml

### DIFF
--- a/IETF-RFC.md
+++ b/IETF-RFC.md
@@ -692,25 +692,52 @@ contain the following information about its OCM API:
     ~~~
             {
               "webdav": "/remote/dav/ocm/",
-              "webapp": "/app/ocm/",
+              "webdav-receive": { "uri": "absolute" },
+              "webapp": {},
+              "webapp-receive": { "targets": ["blank", "iframe"] },
               "talk": "/apps/spreed/api/"
             }
     ~~~
     {: type="json"}
 
+    The `protocols` object distinguishes a server's role for each
+    protocol: a property named after the protocol (e.g. `webdav`,
+    `webapp`, `ssh`) advertises support for acting as a Sending
+    Server, while a property suffixed with `-receive` (e.g.
+    `webdav-receive`, `webapp-receive`, `ssh-receive`) advertises
+    support for acting as a Receiving Server.
+
     Fields:
     - webdav (string) - The top-level WebDAV [RFC4918] path at this
       endpoint.  In order to access a Remote Resource, implementations
       SHOULD use this path as a prefix (see sharing examples).
-    - webapp (string) - The top-level path for web apps at this
-      endpoint.  In order to access a remote web app, implementations
-      SHOULD use this path as a prefix (see sharing examples).
+    - webdav-receive (object) - Advertised by implementations that
+      support receiving WebDAV shares.  It contains a `uri` property
+      whose value MUST be either `"absolute"` or `"relative"`,
+      signalling the URI format this endpoint accepts.  Note that
+      older implementations MAY not support this property.
+    - webapp (object) - Advertised, as an empty object, by
+      implementations that support sending WebApp shares.
+    - webapp-receive (object) - Advertised by implementations that
+      support receiving WebApp shares.  It contains a `targets`
+      array listing the ways this endpoint is able to present a
+      WebApp share to the user.  A subset of:
+      - `blank` - the endpoint can open the URI in a new window or
+        tab.
+      - `redirect` - the endpoint can navigate the browser to the
+        URI, replacing the current page.
+      - `iframe` - the endpoint can embed the URI in an iframe
+        within its own UI, and can set CORS headers.
     - ssh (string) - The top-level address in the form `host:port`
       of an endpoint that supports ssh and scp with a public/private
       key based authentication.
+    - ssh-receive (object) - Advertised, as an empty object, by
+      implementations that support receiving SSH shares.
     - Any additional protocol supported for this Resource type MAY be
       advertised here, where the value MAY correspond to
-      a top-level URI to be used for that protocol.
+      a top-level URI to be used for that protocol.  Similarly,
+      additional receiving capabilities for custom protocols SHOULD
+      be advertised using a `-receive` suffixed property.
 * OPTIONAL: capabilities (array of string) - The optional capabilities
   supported by this OCM Server.
   As implementations MUST accept Share Creation Notifications
@@ -947,20 +974,49 @@ voluntarily.
     especially in case of `datatx` access type.
 * Protocol details for `webapp` MAY contain:
   - REQUIRED uri (string)
-    A URI to a client-browsable view of the Shared
-    Resource, such that users MAY use the web
-    applications available at the site.  The URI SHOULD
-    be relative, in which case the prefix exposed by
-    the `/.well-known/ocm` endpoint MUST be used.
-    Absolute URIs are deprecated.
-  - REQUIRED viewMode (string)
-    The permissions granted to the sharee.  A subset of:
+    A URI to a client-browsable view of the Shared Resource, such
+    that users MAY use a web application available at the Sending
+    Server.  The URI MUST be absolute, including a hostname.  In
+    case the underlying Resource is a folder, the URI MUST act as a
+    root path, such that files located within the folder are made
+    accessible in the web app by appending their relative path to
+    the URI.
+  - REQUIRED targets (array of strings) - How the recipient SHOULD
+    present the URI to the user.  MUST NOT be empty.  A subset of:
+    - `blank` signals the recipient to open the URI in a new window
+      or tab.
+    - `redirect` signals the recipient to navigate the browser to
+      the URI, replacing the current page.
+    - `iframe` signals the recipient to embed the URI in an iframe
+      within its own UI.  CORS headers MUST be properly set.
+    A Sending Server MUST NOT offer a target that the recipient did
+    not advertise in its `webapp-receive` discovery property.
+  - REQUIRED permissions (array of strings) -
+    The permissions granted to the sharee.  MUST NOT be empty.
+    A subset of:
     - `view` allows access to the web app in view-only mode.
     - `read` allows read and download access via the web app.
     - `write` allows full editing rights via the web app.
+    - `share` allows re-share rights on the Resource.  This only
+      applies to web apps that provide a mechanism for re-sharing.
   - OPTIONAL sharedSecret (string)
-    An optional secret to be used to access the remote
-    web app, for example in the form of a bearer token.
+    A secret for accessing the remote web app, such as a bearer
+    token.  To give access to the remote app, the receiver MUST
+    perform an HTTP POST request to the given `uri`, passing the
+    shared secret in a form field named `access_token` (see
+    [Resource Access](#resource-access)).  To prevent leaking it in
+    logs it MUST NOT appear in any URI.  In a multi-protocol Share
+    that also offers WebDAV, the access requirements provided in the
+    `webdav` part (such as `must-exchange-token`) MUST apply to
+    `webapp` accesses as well.
+  - OPTIONAL appName (string)
+    A human-friendly name of the web application, to be used in user
+    interfaces when referring to this Share.
+  - OPTIONAL appIcon (string)
+    A URI to an icon representing the web application, to be used in
+    user interfaces when referring to this Share.  An embedded data
+    URI MAY be used; alternatively, if a regular URI is used, it MUST
+    be absolute, including a hostname.
 * Protocol details for `ssh` MAY contain:
   - OPTIONAL accessTypes (array of strings) - The type of access
     being granted to the remote resource.  If omitted, it defaults to
@@ -1163,6 +1219,22 @@ protocol required for access.  The procedure is as follows:
    removed in a future release of the Protocol.  If a secret cannot be
    identified (e.g. because `protocol.options` is undefined), then
    the receiver SHOULD discard the share as invalid.
+6. For the specific case where `protocol.webapp` is available and the
+   receiver wants to use it, the receiver MUST present the web app to
+   the user by opening `protocol.webapp.uri` using one of the targets
+   listed in `protocol.webapp.targets` (defaulting to `blank`), chosen
+   among those the receiver advertises in its `webapp-receive`
+   discovery property.  If a `protocol.webapp.sharedSecret` is present,
+   the receiver MUST NOT place it in the URI; instead it MUST deliver
+   it to the web app via an HTTP POST to `protocol.webapp.uri` with the
+   secret carried in a form field named `access_token`.  This is
+   typically achieved with an auto-submitting HTML form whose `target`
+   attribute selects the chosen presentation (e.g. an iframe name,
+   `_blank`, or `_top`).  When the Share also requires token exchange
+   (see step 3.1, applied via the `webdav` part of a multi-protocol
+   Share), the receiver MUST first exchange the `sharedSecret` at the
+   Sending Server's {tokenEndPoint} and POST the resulting bearer token
+   as the `access_token` value.
 
 In all cases, in case the Shared Resource is a folder and the Receiving
 Server accesses a Resource within that shared folder, it SHOULD append
@@ -1928,8 +2000,11 @@ that section.
 |   Protocols      |
 +------------------+
 | - ssh            |
+| - ssh-receive    |
 | - webapp         |
+| - webapp-receive |
 | - webdav         |
+| - webdav-receive |
 | - ...            |
 +------------------+
 ~~~

--- a/IETF-RFC.md
+++ b/IETF-RFC.md
@@ -722,8 +722,9 @@ contain the following information about its OCM API:
       support receiving WebApp shares.  It contains a `targets`
       array listing the ways this endpoint is able to present a
       WebApp share to the user.  A subset of:
-      - `blank` - the endpoint can open the URI in a new window or
-        tab, or do a full page redirect.
+      - `blank` - the endpoint can open the URI in a top-level
+        browsing context, such as a new window or tab, or a full page
+        navigation in the current window.
       - `iframe` - the endpoint can embed the URI in an iframe
         within its own UI, when the Sending Server allows framing
         by this receiver.
@@ -778,7 +779,8 @@ contain the following information about its OCM API:
   - `"must-exchange-token"` - to indicate that when this OCM Server
   acts as Receiving Server, it requires the code flow for all inbound
   shares.  Shares that do not include `must-exchange-token` in
-  their `protocol.webdav.requirements` will be rejected.  An
+  the requirements of each protocol offered for access will be
+  rejected.  An
   OCM Server advertising this criterium MUST also expose the
   `exchange-token` capability.  See the [Code Flow](#code-flow)
   section.
@@ -823,8 +825,8 @@ the Receiving Server's OCM API Discovery endpoint.  If the Receiving
 Server advertises `must-exchange-token` in its `criteria` and the
 Sending Server exposes the `exchange-token` capability with a
 `tokenEndPoint`, the Sending Server MUST include `must-exchange-token`
-in `protocol.webdav.requirements` and MUST NOT fall back to legacy
-shared-secret access.  If the Receiving Server advertises
+in the requirements of each protocol offered for access and MUST NOT
+fall back to legacy shared-secret access.  If the Receiving Server advertises
 `must-exchange-token` but the Sending Server does not expose the
 `exchange-token` capability or does not have a `tokenEndPoint`, the
 Sending Server MUST NOT create the share, as the Receiving Server
@@ -832,6 +834,13 @@ would reject any notification that lacks the code-flow requirement.
 If the Receiving Server does not advertise `must-exchange-token` in its
 `criteria`, the Sending Server MAY still include `must-exchange-token`
 voluntarily.
+
+When the notification includes `protocol.webapp`, the Sending Server
+MUST expose the `exchange-token` capability and a `tokenEndPoint`,
+because WebApp access requires the Receiving Server to exchange
+`protocol.webapp.sharedSecret` before presenting the WebApp to the
+browser.  If the Sending Server cannot offer this code flow, it MUST NOT
+include `protocol.webapp` in the notification.
 
 ## Fields
 
@@ -983,8 +992,9 @@ voluntarily.
   - REQUIRED targets (array of strings) - How the recipient SHOULD
     present the URI to the user.  The `targets` array MUST NOT be
     empty.  A subset of:
-    - `blank` signals the recipient to open the URI in a new window
-      or tab.
+    - `blank` signals the recipient to open the URI in a top-level
+      browsing context chosen by the receiver, such as a new window or
+      tab, or a full page navigation in the current window.
     - `iframe` signals the recipient to embed the URI in an iframe
       within its own UI, when the Sending Server allows framing by
       this receiver.
@@ -1021,11 +1031,17 @@ voluntarily.
   - OPTIONAL appIconHint (string)
     A string in the form of a media type (MIME type) that describes the
     share as a whole, primarily intended as a way for the receiving
-    server to select an appropriate icon for the share. [RFC6838]
+    server to select an appropriate local icon for the share.  This is
+    display metadata and MUST NOT be interpreted as fetchable or
+    executable content.  It does not need to appear in `mediaTypes`, but
+    SHOULD describe the primary shared resource. [RFC6838]
   - OPTIONAL mediaTypes (array of strings)
     An array of media types (MIME types) the webapp server can handle.
     This can be any media type entries from the IANA Media Type
-    registry. [RFC6838]
+    registry.  The receiver MAY use this as a hint for UI or routing
+    decisions, and MAY ignore values it does not understand.  Unlike
+    `appIconHint`, this describes formats the webapp can open rather
+    than the share-level icon hint. [RFC6838]
 * Protocol details for `ssh` MAY contain:
   - OPTIONAL accessTypes (array of strings) - The type of access
     being granted to the remote resource.  If omitted, it defaults to
@@ -1234,19 +1250,29 @@ protocol required for access.  The procedure is as follows:
    from the intersection of `protocol.webapp.targets` and the targets
    advertised in the receiver's `webapp-receive` discovery property.
    If this intersection is empty, the receiver MUST treat the `webapp`
-   option as unusable for this Share.  The receiver MUST NOT place the
+   option as unusable for this Share.  If the selected target is
+   `blank`, the receiver MAY use `_blank` or `_top` according to its
+   local presentation policy.  The receiver MUST inspect
+   `protocol.webapp.requirements`: if it includes `must-use-mfa`, the
+   Receiving Server MUST ensure that the Receiving Party has been
+   authenticated with MFA, or prompt the consumer in order to elevate
+   their session, if applicable.  The receiver MUST NOT place the
    `protocol.webapp.sharedSecret` in the URI and MUST NOT expose it to
-   the browser.  Instead,
-   the receiver MUST first exchange it at the Sending Server's
-   {tokenEndPoint} using the Code Flow, then deliver the resulting
-   bearer token to the web app via an HTTP POST to
+   the browser.  Instead, the receiver MUST first exchange it at the
+   Sending Server's {tokenEndPoint} using the Code Flow, then deliver
+   the resulting bearer token to the web app via an HTTP POST to
    `protocol.webapp.uri` with the token carried in a form field named
    `access_token` along with another form field named
-   `expired_session_redirect_uri` that represents the location where
-   the receiving server can handle refresh of tokens.  This is typically
-   achieved with an auto-submitting HTML form whose `target` attribute
-   selects the chosen presentation (e.g. an iframe name, `_blank`, or
-   `_top`).
+   `expired_session_redirect_uri`.  The
+   `expired_session_redirect_uri` value MUST be an absolute HTTPS URI
+   controlled by the Receiving Server.  The Sending WebApp MAY navigate
+   the browser to this URI when the posted session expires so that the
+   Receiving Server can restart access and obtain a fresh token; it
+   MUST NOT place the shared secret or access token in that URI.
+   Sending WebApps that do not support session refresh MAY ignore this
+   field.  This is typically achieved with an auto-submitting HTML form whose
+   `target` attribute selects the chosen presentation (e.g. an iframe
+   name, `_blank`, or `_top`).
 
 In all cases, in case the Shared Resource is a folder and the Receiving
 Server accesses a Resource within that shared folder, it SHOULD append

--- a/IETF-RFC.md
+++ b/IETF-RFC.md
@@ -1246,7 +1246,7 @@ protocol required for access.  The procedure is as follows:
    `protocol.webapp.uri` with the token carried in a form field named
    `access_token` along with another form field named
    `expired_session_redirect_uri` that represents the location where
-   the reciving server can handle refresh of tokens.  This is typically
+   the receiving server can handle refresh of tokens.  This is typically
    achieved with an auto-submitting HTML form whose `target` attribute
    selects the chosen presentation (e.g. an iframe name, `_blank`, or
    `_top`).
@@ -1255,7 +1255,7 @@ In all cases, in case the Shared Resource is a folder and the Receiving
 Server accesses a Resource within that shared folder, it SHOULD append
 its relative path to that URL.  In other words, the Sending Server
 SHOULD support requests to URLs such as
-`https://<sender-host><sender-ocm-path>/path/to/resource.txt`. 
+`https://<sender-host><sender-ocm-path>/path/to/resource.txt`.
 
 
 # Code Flow
@@ -1572,9 +1572,9 @@ June 2007.
 [RFC6749] Hardt, D. (ed), "[The OAuth 2.0 Authorization Framework](
 https://datatracker.ietf.org/html/rfc6749)", October 2012.
 
-[RFC6828] Freed, N., Klensin, J., Hansen, T. "[Media Type
+[RFC6838] Freed, N., Klensin, J., Hansen, T. "[Media Type
 Specifications and Registration Procedures
-](https://datatracker.ietf.org/html/rfc6828)", January 2013.
+](https://datatracker.ietf.org/html/rfc6838)", January 2013.
 
 [RFC7515] Jones, M., Bradley, J., Sakimura, N., "[JSON Web Signature
 (JWS)](https://datatracker.ietf.org/doc/html/rfc7515)", May 2015.

--- a/IETF-RFC.md
+++ b/IETF-RFC.md
@@ -723,9 +723,7 @@ contain the following information about its OCM API:
       array listing the ways this endpoint is able to present a
       WebApp share to the user.  A subset of:
       - `blank` - the endpoint can open the URI in a new window or
-        tab.
-      - `redirect` - the endpoint can navigate the browser to the
-        URI, replacing the current page.
+        tab, or do a full page redirect.
       - `iframe` - the endpoint can embed the URI in an iframe
         within its own UI, when the Sending Server allows framing
         by this receiver.
@@ -987,8 +985,6 @@ voluntarily.
     empty.  A subset of:
     - `blank` signals the recipient to open the URI in a new window
       or tab.
-    - `redirect` signals the recipient to navigate the browser to
-      the URI, replacing the current page.
     - `iframe` signals the recipient to embed the URI in an iframe
       within its own UI, when the Sending Server allows framing by
       this receiver.

--- a/IETF-RFC.md
+++ b/IETF-RFC.md
@@ -1238,9 +1238,11 @@ protocol required for access.  The procedure is as follows:
    {tokenEndPoint} using the Code Flow, then deliver the resulting
    bearer token to the web app via an HTTP POST to
    `protocol.webapp.uri` with the token carried in a form field named
-   `access_token`.  This is typically achieved with an auto-submitting
-   HTML form whose `target` attribute selects the chosen presentation
-   (e.g. an iframe name, `_blank`, or `_top`).
+   `access_token` along with another form field named `redirect_uri`
+   that represents the location where the reciving server can handle
+   refresh of tokens.  This is typically achieved with an
+   auto-submitting HTML form whose `target` attribute selects the
+   chosen presentation (e.g. an iframe name, `_blank`, or `_top`).
 
 In all cases, in case the Shared Resource is a folder and the Receiving
 Server accesses a Resource within that shared folder, it SHOULD append

--- a/IETF-RFC.md
+++ b/IETF-RFC.md
@@ -727,7 +727,8 @@ contain the following information about its OCM API:
       - `redirect` - the endpoint can navigate the browser to the
         URI, replacing the current page.
       - `iframe` - the endpoint can embed the URI in an iframe
-        within its own UI, and can set CORS headers.
+        within its own UI, when the Sending Server allows framing
+        by this receiver.
     - ssh (string) - The top-level address in the form `host:port`
       of an endpoint that supports ssh and scp with a public/private
       key based authentication.
@@ -743,7 +744,7 @@ contain the following information about its OCM API:
   As implementations MUST accept Share Creation Notifications
   to be compliant, it is not necessary to expose that as a
   capability.
-  Example: `["exchange-token", "webdav-uri"]`.  The array MAY
+  Example: `["exchange-token", "protocol-object"]`.  The array MAY
   include one or more of the following items:
   - `"enforce-mfa"` - to indicate that this OCM Server can apply a
   Sending Server's MFA requirements for a Share on their behalf.
@@ -764,9 +765,6 @@ contain the following information about its OCM API:
   notifications to exchange updates on shares and invites.
   - `"invite-wayf"` - to indicate that this OCM Server exposes a WAYF
   Page to facilitate the Invite flow.
-  - `"webdav-uri"` - to indicate that this OCM Server can append a
-  relative URI to the path listed for WebDAV [RFC4918] in the
-  appropriate `resourceTypes` entry
   - `"protocol-object"` - to indicate that this OCM Server can
   receive a Share Creation Notification whose `protocol` object
   contains one property per supported protocol instead of containing
@@ -943,10 +941,13 @@ voluntarily.
     cache operations on the Sending Server.  The recipient MAY delegate
     a third-party service to execute the data transfer on their behalf.
   - REQUIRED uri (string)
-    A URI to access the Remote Resource.  The URI
-    SHOULD be relative, in which case the prefix
-    exposed by the `/.well-known/ocm` endpoint MUST
-    be used.  Absolute URIs are deprecated.
+    A URI to access the Remote Resource.  The URI MAY be relative,
+    such as a key or a UUID, in which case the prefix exposed by the
+    `/.well-known/ocm` endpoint MUST be used to access the Resource,
+    or it MAY be absolute, including a hostname.  In all cases, for a
+    `folder` Resource, the composed URI acts as the root path, such
+    that other files located within it MUST be accessible by
+    appending their relative path to that URI.
   - REQUIRED sharedSecret (string)
     A secret to be used to access the Resource, such as
     a bearer token.  To prevent leaking it in logs it
@@ -982,13 +983,15 @@ voluntarily.
     accessible in the web app by appending their relative path to
     the URI.
   - REQUIRED targets (array of strings) - How the recipient SHOULD
-    present the URI to the user.  MUST NOT be empty.  A subset of:
+    present the URI to the user.  The `targets` array MUST NOT be
+    empty.  A subset of:
     - `blank` signals the recipient to open the URI in a new window
       or tab.
     - `redirect` signals the recipient to navigate the browser to
       the URI, replacing the current page.
     - `iframe` signals the recipient to embed the URI in an iframe
-      within its own UI.  CORS headers MUST be properly set.
+      within its own UI, when the Sending Server allows framing by
+      this receiver.
     A Sending Server MUST NOT offer a target that the recipient did
     not advertise in its `webapp-receive` discovery property.
   - REQUIRED permissions (array of strings) -
@@ -1000,23 +1003,26 @@ voluntarily.
     - `share` allows re-share rights on the Resource.  This only
       applies to web apps that provide a mechanism for re-sharing.
   - OPTIONAL sharedSecret (string)
-    A secret for accessing the remote web app, such as a bearer
-    token.  To give access to the remote app, the receiver MUST
-    perform an HTTP POST request to the given `uri`, passing the
-    shared secret in a form field named `access_token` (see
-    [Resource Access](#resource-access)).  To prevent leaking it in
-    logs it MUST NOT appear in any URI.  In a multi-protocol Share
-    that also offers WebDAV, the access requirements provided in the
-    `webdav` part (such as `must-exchange-token`) MUST apply to
-    `webapp` accesses as well.
+    A secret for accessing the remote web app.  To give access to the
+    remote app, the receiver MUST first exchange this value at the
+    Sending Server's {tokenEndPoint} using the Code Flow, then perform
+    an HTTP POST request to the given `uri` with the resulting bearer
+    token in a form field named `access_token` (see
+    [Resource Access](#resource-access)).  The shared secret MUST NOT
+    be exposed to the browser and MUST NOT appear in any URI.  In a
+    multi-protocol Share that also offers WebDAV, the access
+    requirements provided in the `webdav` part (such as
+    `must-exchange-token`) MUST apply to `webapp` accesses as well.
   - OPTIONAL appName (string)
     A human-friendly name of the web application, to be used in user
     interfaces when referring to this Share.
   - OPTIONAL appIcon (string)
     A URI to an icon representing the web application, to be used in
     user interfaces when referring to this Share.  An embedded data
-    URI MAY be used; alternatively, if a regular URI is used, it MUST
-    be absolute, including a hostname.
+    URI MAY be used if it identifies an image resource; alternatively,
+    if a regular URI is used, it MUST be absolute, including a
+    hostname.  Receiving Servers MUST render the icon only in an inert
+    image context and MAY reject unsupported or unsafe image types.
 * Protocol details for `ssh` MAY contain:
   - OPTIONAL accessTypes (array of strings) - The type of access
     being granted to the remote resource.  If omitted, it defaults to
@@ -1221,20 +1227,20 @@ protocol required for access.  The procedure is as follows:
    the receiver SHOULD discard the share as invalid.
 6. For the specific case where `protocol.webapp` is available and the
    receiver wants to use it, the receiver MUST present the web app to
-   the user by opening `protocol.webapp.uri` using one of the targets
-   listed in `protocol.webapp.targets` (defaulting to `blank`), chosen
-   among those the receiver advertises in its `webapp-receive`
-   discovery property.  If a `protocol.webapp.sharedSecret` is present,
-   the receiver MUST NOT place it in the URI; instead it MUST deliver
-   it to the web app via an HTTP POST to `protocol.webapp.uri` with the
-   secret carried in a form field named `access_token`.  This is
-   typically achieved with an auto-submitting HTML form whose `target`
-   attribute selects the chosen presentation (e.g. an iframe name,
-   `_blank`, or `_top`).  When the Share also requires token exchange
-   (see step 3.1, applied via the `webdav` part of a multi-protocol
-   Share), the receiver MUST first exchange the `sharedSecret` at the
-   Sending Server's {tokenEndPoint} and POST the resulting bearer token
-   as the `access_token` value.
+   the user by opening `protocol.webapp.uri` using a target selected
+   from the intersection of `protocol.webapp.targets` and the targets
+   advertised in the receiver's `webapp-receive` discovery property.
+   If this intersection is empty, the receiver MUST treat the `webapp`
+   option as unusable for this Share.  If a
+   `protocol.webapp.sharedSecret` is present, the receiver MUST NOT
+   place it in the URI and MUST NOT expose it to the browser.  Instead,
+   the receiver MUST first exchange it at the Sending Server's
+   {tokenEndPoint} using the Code Flow, then deliver the resulting
+   bearer token to the web app via an HTTP POST to
+   `protocol.webapp.uri` with the token carried in a form field named
+   `access_token`.  This is typically achieved with an auto-submitting
+   HTML form whose `target` attribute selects the chosen presentation
+   (e.g. an iframe name, `_blank`, or `_top`).
 
 In all cases, in case the Shared Resource is a folder and the Receiving
 Server accesses a Resource within that shared folder, it SHOULD append
@@ -1976,7 +1982,6 @@ that section.
 | - ...            |  | - invites        |          |
 +------------------+  | - notifications  |          |
        |              | - protocol-object|          |
-       |              | - webdav-uri     |          |
        |              | - ...            |          |
        |              +------------------+          |
        |                                            |

--- a/IETF-RFC.md
+++ b/IETF-RFC.md
@@ -1007,7 +1007,7 @@ voluntarily.
     as a webdav share, both protocols MUST carry the same
     requirements, and both requirement arrays MUST include
     `must-exchange-token`.
-  - OPTIONAL sharedSecret (string)
+  - REQUIRED sharedSecret (string)
     A secret for accessing the remote web app.  To give access to the
     remote app, the receiver MUST first exchange this value at the
     Sending Server's {tokenEndPoint} using the Code Flow, then perform
@@ -1237,9 +1237,9 @@ protocol required for access.  The procedure is as follows:
    from the intersection of `protocol.webapp.targets` and the targets
    advertised in the receiver's `webapp-receive` discovery property.
    If this intersection is empty, the receiver MUST treat the `webapp`
-   option as unusable for this Share.  If a
-   `protocol.webapp.sharedSecret` is present, the receiver MUST NOT
-   place it in the URI and MUST NOT expose it to the browser.  Instead,
+   option as unusable for this Share.  The receiver MUST NOT place the
+   `protocol.webapp.sharedSecret` in the URI and MUST NOT expose it to
+   the browser.  Instead,
    the receiver MUST first exchange it at the Sending Server's
    {tokenEndPoint} using the Code Flow, then deliver the resulting
    bearer token to the web app via an HTTP POST to

--- a/IETF-RFC.md
+++ b/IETF-RFC.md
@@ -826,11 +826,12 @@ Server advertises `must-exchange-token` in its `criteria` and the
 Sending Server exposes the `exchange-token` capability with a
 `tokenEndPoint`, the Sending Server MUST include `must-exchange-token`
 in the requirements of each protocol offered for access and MUST NOT
-fall back to legacy shared-secret access.  If the Receiving Server advertises
-`must-exchange-token` but the Sending Server does not expose the
-`exchange-token` capability or does not have a `tokenEndPoint`, the
-Sending Server MUST NOT create the share, as the Receiving Server
-would reject any notification that lacks the code-flow requirement.
+fall back to legacy shared-secret access.  If the Receiving
+Server advertises `must-exchange-token` but the Sending Server does
+not expose the `exchange-token` capability or does not have a
+`tokenEndPoint`, the Sending Server MUST NOT create the share, 
+as the Receiving Server would reject any notification that lacks 
+the code-flow requirement.
 If the Receiving Server does not advertise `must-exchange-token` in its
 `criteria`, the Sending Server MAY still include `must-exchange-token`
 voluntarily.
@@ -1270,9 +1271,9 @@ protocol required for access.  The procedure is as follows:
    Receiving Server can restart access and obtain a fresh token; it
    MUST NOT place the shared secret or access token in that URI.
    Sending WebApps that do not support session refresh MAY ignore this
-   field.  This is typically achieved with an auto-submitting HTML form whose
-   `target` attribute selects the chosen presentation (e.g. an iframe
-   name, `_blank`, or `_top`).
+   field.  This is typically achieved with an auto-submitting
+   HTML form whose `target` attribute selects the chosen
+   presentation (e.g. an iframe name, `_blank`, or `_top`).
 
 In all cases, in case the Shared Resource is a folder and the Receiving
 Server accesses a Resource within that shared folder, it SHOULD append

--- a/IETF-RFC.md
+++ b/IETF-RFC.md
@@ -998,6 +998,15 @@ voluntarily.
     - `write` allows full editing rights via the web app.
     - `share` allows re-share rights on the Resource.  This only
       applies to web apps that provide a mechanism for re-sharing.
+  - REQUIRED requirements (array of strings) -
+    The requirements that the sharee MUST fulfill to
+    access the Resource.  The requirements MUST at least include
+    `must-exchange-token`.  If multiple protocols are present in the
+    share payload, the requirements for the different protocols MUST
+    agree.  For example, if a webapp share is sent in the same payload
+    as a webdav share, both protocols MUST carry the same
+    requirements, and both requirement arrays MUST include
+    `must-exchange-token`.
   - OPTIONAL sharedSecret (string)
     A secret for accessing the remote web app.  To give access to the
     remote app, the receiver MUST first exchange this value at the
@@ -1012,11 +1021,14 @@ voluntarily.
   - OPTIONAL appName (string)
     A human-friendly name of the web application, to be used in user
     interfaces when referring to this Share.
-  - OPTIONAL mediaType (string)
-    A string that describes the main media type (MIME type) of the
-    share.  This can be media types with vendor tree subtypes, such as
-    `application/vnd.jupyter` for Jupyter Notebooks, or any entries from
-    the IANA Media Type registry. [RFC6838]
+  - OPTIONAL appIconHint (string)
+    A string in the form of a media type (MIME type) that describes the
+    share as a whole, primarily intended as a way for the receiving
+    server to select an appropriate icon for the share. [RFC6838]
+  - OPTIONAL mediaTypes (array of strings)
+    An array of media types (MIME types) the webapp server can handle.
+    This can be any media type entries from the IANA Media Type
+    registry. [RFC6838]
 * Protocol details for `ssh` MAY contain:
   - OPTIONAL accessTypes (array of strings) - The type of access
     being granted to the remote resource.  If omitted, it defaults to
@@ -1232,17 +1244,18 @@ protocol required for access.  The procedure is as follows:
    {tokenEndPoint} using the Code Flow, then deliver the resulting
    bearer token to the web app via an HTTP POST to
    `protocol.webapp.uri` with the token carried in a form field named
-   `access_token` along with another form field named `redirect_uri`
-   that represents the location where the reciving server can handle
-   refresh of tokens.  This is typically achieved with an
-   auto-submitting HTML form whose `target` attribute selects the
-   chosen presentation (e.g. an iframe name, `_blank`, or `_top`).
+   `access_token` along with another form field named
+   `expired_session_redirect_uri` that represents the location where
+   the reciving server can handle refresh of tokens.  This is typically
+   achieved with an auto-submitting HTML form whose `target` attribute
+   selects the chosen presentation (e.g. an iframe name, `_blank`, or
+   `_top`).
 
 In all cases, in case the Shared Resource is a folder and the Receiving
 Server accesses a Resource within that shared folder, it SHOULD append
 its relative path to that URL.  In other words, the Sending Server
 SHOULD support requests to URLs such as
-`https://<sender-host><sender-ocm-path>/path/to/resource.txt`.
+`https://<sender-host><sender-ocm-path>/path/to/resource.txt`. 
 
 
 # Code Flow

--- a/IETF-RFC.md
+++ b/IETF-RFC.md
@@ -1014,10 +1014,7 @@ voluntarily.
     an HTTP POST request to the given `uri` with the resulting bearer
     token in a form field named `access_token` (see
     [Resource Access](#resource-access)).  The shared secret MUST NOT
-    be exposed to the browser and MUST NOT appear in any URI.  In a
-    multi-protocol Share that also offers WebDAV, the access
-    requirements provided in the `webdav` part (such as
-    `must-exchange-token`) MUST apply to `webapp` accesses as well.
+    be exposed to the browser and MUST NOT appear in any URI.
   - OPTIONAL appName (string)
     A human-friendly name of the web application, to be used in user
     interfaces when referring to this Share.

--- a/IETF-RFC.md
+++ b/IETF-RFC.md
@@ -1016,13 +1016,11 @@ voluntarily.
   - OPTIONAL appName (string)
     A human-friendly name of the web application, to be used in user
     interfaces when referring to this Share.
-  - OPTIONAL appIcon (string)
-    A URI to an icon representing the web application, to be used in
-    user interfaces when referring to this Share.  An embedded data
-    URI MAY be used if it identifies an image resource; alternatively,
-    if a regular URI is used, it MUST be absolute, including a
-    hostname.  Receiving Servers MUST render the icon only in an inert
-    image context and MAY reject unsupported or unsafe image types.
+  - OPTIONAL mediaType (string)
+    A string that describes the main media type (MIME type) of the
+    share.  This can be media types with vendor tree subtypes, such as
+    `application/vnd.jupyter` for Jupyter Notebooks, or any entries from
+    the IANA Media Type registry. [RFC6838]
 * Protocol details for `ssh` MAY contain:
   - OPTIONAL accessTypes (array of strings) - The type of access
     being granted to the remote resource.  If omitted, it defaults to
@@ -1564,6 +1562,10 @@ June 2007.
 
 [RFC6749] Hardt, D. (ed), "[The OAuth 2.0 Authorization Framework](
 https://datatracker.ietf.org/html/rfc6749)", October 2012.
+
+[RFC6828] Freed, N., Klensin, J., Hansen, T. "[Media Type
+Specifications and Registration Procedures
+](https://datatracker.ietf.org/html/rfc6828)", January 2013.
 
 [RFC7515] Jones, M., Bradley, J., Sakimura, N., "[JSON Web Signature
 (JWS)](https://datatracker.ietf.org/doc/html/rfc7515)", May 2015.

--- a/diagrams/share-creation-preflight.md
+++ b/diagrams/share-creation-preflight.md
@@ -1,7 +1,11 @@
 ```mermaid
 flowchart TD
     A["Sending Server wants to create a share"]
-    A --> B["Query Receiving Server discovery"]
+    A --> W{"Share includes protocol.webapp"}
+    W -- "Yes" --> X{"Sender exposes exchange-token and tokenEndPoint"}
+    X -- "No" --> Y["Do not include webapp in the share"]
+    X -- "Yes" --> B["Query Receiving Server discovery"]
+    W -- "No" --> B
     B --> C{"Receiver advertises must-exchange-token"}
 
     C -- "Yes" --> D{"Sender exposes exchange-token and tokenEndPoint"}

--- a/diagrams/webapp-resource-access.md
+++ b/diagrams/webapp-resource-access.md
@@ -1,0 +1,42 @@
+# WebApp Resource Access
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor RP as "Receiving Party"
+    participant B as "Receiving Party's Browser"
+    participant RS as "Receiving Server"
+    participant TE as "Sending Server<br/>tokenEndPoint"
+    participant SWA as "Sending WebApp<br/>(protocol.webapp.uri)"
+
+    RP->>B: Open shared WebApp in local UI
+    B->>RS: Request WebApp presentation
+
+    RS->>RS: Intersect protocol.webapp.targets<br/>with webapp-receive.targets
+
+    alt No common target
+        RS-->>B: WebApp unusable for this share
+    else Common target selected (iframe or blank)
+        opt protocol.webapp.requirements includes must-use-mfa
+            RS->>B: Ensure MFA-authenticated session<br/>(or prompt to elevate)
+            B-->>RS: MFA session established
+        end
+
+        Note over RS,TE: sharedSecret stays server-side.<br/>Never in browser.
+
+        RS->>TE: Signed Code Flow POST<br/>code=protocol.webapp.sharedSecret
+        TE-->>RS: access_token (short-lived bearer)
+
+        RS->>B: Auto-submit HTML form<br/>target iframe, _blank, or _top
+        B->>SWA: POST protocol.webapp.uri<br/>access_token + refresh URI
+
+        Note over B,SWA: Browser receives access_token only, never sharedSecret.
+        SWA-->>B: Establish session and serve WebApp UI
+
+        opt Posted session expires later
+            SWA->>B: Navigate to expired_session_redirect_uri<br/>(no tokens)
+            B->>RS: Receiver-controlled restart endpoint
+            Note over RS,SWA: Receiver may repeat exchange<br/>and form POST.
+        end
+    end
+```

--- a/schemas/ocm-discovery.json
+++ b/schemas/ocm-discovery.json
@@ -29,7 +29,7 @@
     },
     "criteria": {
       "type": "array",
-      "description": "Criteria values of 'http-request-signatures', 'must-exchange-token', 'denylist', 'allowlist', and 'invite' are defined in the draft",
+      "description": "Criteria values of 'must-use-http-sig', 'must-exchange-token', 'denylist', 'allowlist', and 'must-invite' are defined in the draft",
       "items": {
         "type": "string"
       }

--- a/schemas/ocm-discovery.json
+++ b/schemas/ocm-discovery.json
@@ -22,7 +22,7 @@
     },
     "capabilities": {
       "type": "array",
-      "description": "Capability values of 'enforce-mfa', 'exchange-token', 'http-sig', 'invites', 'invite-wayf', 'notifications', 'protocol-object', and 'webdav-uri' are defined in the draft",
+      "description": "Capability values of 'enforce-mfa', 'exchange-token', 'http-sig', 'invites', 'invite-wayf', 'notifications', and 'protocol-object' are defined in the draft",
       "items": {
         "type": "string"
       }
@@ -55,6 +55,7 @@
   ],
   "$defs": {
     "resourceType": {
+      "type": "object",
       "properties": {
         "name": {
           "type": "string"
@@ -69,20 +70,53 @@
     "protocols": {
       "type": "object",
       "minProperties": 1,
-      "description": "Additional protocols besides 'webdav', 'webapp' and 'datatx' may be defined.",
+      "description": "Additional protocols besides 'webdav', 'webapp', and 'ssh' may be defined. A property named after the protocol advertises sending support; a property suffixed with '-receive' advertises receiving support.",
       "properties": {
         "webdav": {
           "type": "string",
           "pattern": "^/"
         },
-        "webapp": {
-          "type": "string",
-          "pattern": "^/"
+        "webdav-receive": {
+          "type": "object",
+          "required": ["uri"],
+          "properties": {
+            "uri": { "type": "string", "enum": ["absolute", "relative"] }
+          },
+          "additionalProperties": false
         },
-        "datatx": {
-          "type": "string",
-          "pattern": "^/"
+        "webapp": {
+          "type": "object",
+          "additionalProperties": false
+        },
+        "webapp-receive": {
+          "type": "object",
+          "required": ["targets"],
+          "properties": {
+            "targets": {
+              "type": "array",
+              "minItems": 1,
+              "uniqueItems": true,
+              "items": {
+                "type": "string",
+                "enum": ["blank", "redirect", "iframe"]
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        "ssh": {
+          "type": "string"
+        },
+        "ssh-receive": {
+          "type": "object",
+          "additionalProperties": false
         }
+      },
+      "additionalProperties": {
+        "oneOf": [
+          { "type": "string" },
+          { "type": "object" }
+        ]
       }
     },
     "publicKey": {

--- a/schemas/ocm-discovery.json
+++ b/schemas/ocm-discovery.json
@@ -98,7 +98,7 @@
               "uniqueItems": true,
               "items": {
                 "type": "string",
-                "enum": ["blank", "redirect", "iframe"]
+                "enum": ["blank", "iframe"]
               }
             }
           },

--- a/spec.yaml
+++ b/spec.yaml
@@ -834,8 +834,9 @@ components:
                   type: string
                   description: >
                     An optional URI to an icon representing the web application, to be
-                    used in user interfaces when referring to this share. The URI MUST
-                    be absolute, including a hostname.
+                    used in user interfaces when referring to this share. An embedded
+                    data URI can be used. Alternatively, if a regular URI is used,
+                    it MUST be absolute, including a hostname.
             ssh:
               type: object
               properties:

--- a/spec.yaml
+++ b/spec.yaml
@@ -935,6 +935,7 @@ components:
                   - read
                 requirements:
                   - must-use-mfa
+                  - must-exchange-tokem                 
                   - must-exchange-token
               webapp:
                 uri: https://apps.example.org/codimd/7c084226-d9a1-11e6-bf26-cec0c932ce01

--- a/spec.yaml
+++ b/spec.yaml
@@ -847,16 +847,13 @@ components:
                   description: >
                     An optional human-friendly name of the web application to be used
                     in user interfaces when referring to this share.
-                appIcon:
+                mediaType:
                   type: string
                   description: >
-                    An optional URI to an icon representing the web application, to be
-                    used in user interfaces when referring to this share. An embedded
-                    data URI MAY be used if it identifies an image resource.
-                    Alternatively, if a regular URI is used, it MUST be absolute,
-                    including a hostname. Receiving Servers MUST render the icon only
-                    in an inert image context and MAY reject unsupported or unsafe
-                    image types.
+                    An optional string that describes the main media (MIME) type of the
+                    share. For example a folder with a Jupyter Notebook should be given
+                    the mediaType `application/vnd.jupyter` to allow the receiving
+                    server to choose an appropriate icon to display for the share.
             ssh:
               type: object
               properties:

--- a/spec.yaml
+++ b/spec.yaml
@@ -457,7 +457,6 @@ components:
                           type: string
                           enum:
                             - blank
-                            - redirect
                             - iframe
                   ssh:
                     type: string
@@ -799,16 +798,14 @@ components:
                     How the recipient should present the URI to the user.
                     This array is REQUIRED and MUST NOT be empty: a webapp
                     share without a target is invalid.
-                    - "blank" signals the recipient to open the URI in a new window or tab.
-                    - "redirect" signals the recipient to navigate the browser to the URI,
-                      replacing the current page.
+                    - "blank" signals the recipient to open the URI in a new window or
+                    tab, or do a full page redirect.
                     - "iframe" signals the recipient to embed the URI in an iframe within
                       its own UI, when the Sending Server allows framing by the recipient.
                   items:
                     type: string
                     enum:
                       - blank
-                      - redirect
                       - iframe
                 permissions:
                   type: array
@@ -840,18 +837,22 @@ components:
                     multi-protocol share scenario with WebDAV, the access requirements
                     provided in the `webdav` part MUST apply for `webapp` accesses as
                     well.
+                appIconHint:
+                  type: string
+                  description: >
+                    An optional string in the form of a media type (MIME type) that
+                    describes the share as a whole, primarily intended as a way for
+                    the receiving server to select an appropriate icon for the share.
                 appName:
                   type: string
                   description: >
                     An optional human-friendly name of the web application to be used
                     in user interfaces when referring to this share.
-                mediaType:
-                  type: string
+                mediaTypes:
+                  type: array
                   description: >
-                    An optional string that describes the main media (MIME) type of the
-                    share. For example a folder with a Jupyter Notebook should be given
-                    the mediaType `application/vnd.jupyter` to allow the receiving
-                    server to choose an appropriate icon to display for the share.
+                    An optional array that describes the media (MIME) types that the
+                    webapp server can handle.
             ssh:
               type: object
               properties:

--- a/spec.yaml
+++ b/spec.yaml
@@ -439,23 +439,22 @@ components:
                       targets:
                         type: array
                         description: >
-                          The target values this endpoint supports as receiver of
-                          a webapp share, similar to the target attributes in an
-                          HTML `<a>` tag.
+                          The ways this endpoint is able to present a webapp
+                          share to the user when acting as receiver.
                           - "blank" signals that this endpoint supports opening
                             the URI in a new window or tab.
-                          - "iframe" signals that this endpoint supports opening
-                            the URI in the same browsing context, within an iframe,
+                          - "redirect" signals that this endpoint supports
+                            navigating the browser to the URI, replacing the
+                            current page.
+                          - "iframe" signals that this endpoint supports
+                            embedding the URI in an iframe within its own UI,
                             and that it can set CORS headers.
-                          - "popup" signals that this endpoint supports opening
-                            the URI in an embedded popup window, and that it can
-                            set CORS headers.
                         items:
                           type: string
                           enum:
                             - blank
+                            - redirect
                             - iframe
-                            - popup
                   ssh:
                     type: string
                     description: >
@@ -773,6 +772,10 @@ components:
                     in case of `datatx` access type.
             webapp:
               type: object
+              required:
+                - uri
+                - targets
+                - permissions
               properties:
                 uri:
                   type: string
@@ -786,23 +789,25 @@ components:
                 targets:
                   type: array
                   description: >
-                    The target attribute values to be used when opening the URI, such
-                    as in an HTML `<a>` tag.If omitted, it defaults to `["blank"]`.
+                    How the recipient should present the URI to the user.
+                    This array is REQUIRED and MUST NOT be empty: a webapp
+                    share without a target is invalid.
                     - "blank" signals the recipient to open the URI in a new window or tab.
-                    - "iframe" signals the recipient to open the URI in the same browsing
-                      context, within an iframe. CORS headers MUST be properly set.
-                    - "popup" signals the recipient to open the URI in an embedded popup
-                      window. CORS headers MUST be properly set.
+                    - "redirect" signals the recipient to navigate the browser to the URI,
+                      replacing the current page.
+                    - "iframe" signals the recipient to embed the URI in an iframe within
+                      its own UI. CORS headers MUST be properly set.
                   items:
                     type: string
                     enum:
                       - blank
+                      - redirect
                       - iframe
-                      - popup
                 permissions:
                   type: array
                   description: >
-                    The permissions granted to the sharee.
+                    The permissions granted to the sharee. This array is
+                    REQUIRED and MUST NOT be empty.
                     - `view` allows access to the web app in view-only mode.
                     - `read` allows read and download access via the web app.
                     - `write` allows full editing rights via the web app.

--- a/spec.yaml
+++ b/spec.yaml
@@ -447,8 +447,9 @@ components:
                           The ways this endpoint is able to present a webapp
                           share to the user when acting as receiver.
                           - "blank" signals that this endpoint supports opening
-                            the URI in a new window or tab, or doing a full page
-                            redirect to the URI.
+                            the URI in a top-level browsing context, such as a
+                            new window or tab, or a full page navigation in the
+                            current window.
                           - "iframe" signals that this endpoint supports
                             embedding the URI in an iframe within its own UI,
                             when the Sending Server allows framing by this
@@ -521,10 +522,10 @@ components:
               - must-exchange-token
               - denylist
               - allowlist
-              - invite
+              - must-invite
           example:
             - allowlist
-            - invite
+            - must-invite
         publicKey:
           type: object
           deprecated: true
@@ -801,8 +802,9 @@ components:
                     How the recipient should present the URI to the user.
                     This array is REQUIRED and MUST NOT be empty: a webapp
                     share without a target is invalid.
-                    - "blank" signals the recipient to open the URI in a new window or
-                    tab, or do a full page redirect.
+                    - "blank" signals the recipient to open the URI in a top-level
+                    browsing context chosen by the receiver, such as a new window or
+                    tab, or a full page navigation in the current window.
                     - "iframe" signals the recipient to embed the URI in an iframe within
                       its own UI, when the Sending Server allows framing by the recipient.
                   items:
@@ -858,18 +860,22 @@ components:
                     an HTTP POST request to the given URI with the resulting bearer
                     token in a form field named `access_token`, along with another form
                     field named `expired_session_redirect_uri` that represents the
-                    location where the receiving server can handle refresh of tokens.
+                    absolute HTTPS URI where the receiving server can restart access
+                    to the web app when the browser session expires. Web apps that
+                    do not support session refresh MAY ignore this field.
                     The shared secret MUST
                     NOT be exposed to the browser and MUST NOT appear in any URI. In a
-                    multi-protocol share scenario with WebDAV, the access requirements
-                    provided in the `webdav` part MUST apply for `webapp` accesses as
-                    well.
+                    multi-protocol share, requirements that affect shared access policy
+                    MUST agree across the offered protocols.
                 appIconHint:
                   type: string
                   description: >
                     An optional string in the form of a media type (MIME type) that
                     describes the share as a whole, primarily intended as a way for
-                    the receiving server to select an appropriate icon for the share.
+                    the receiving server to select an appropriate local icon for the
+                    share. This is display metadata and MUST NOT be interpreted as
+                    fetchable or executable content. It does not need to appear in
+                    `mediaTypes`, but SHOULD describe the primary shared resource.
                 appName:
                   type: string
                   description: >
@@ -879,7 +885,14 @@ components:
                   type: array
                   description: >
                     An optional array that describes the media (MIME) types that the
-                    webapp server can handle.
+                    webapp server can handle. This is a hint for receiver UI and
+                    routing decisions, and receivers MAY ignore values they do not
+                    understand. Unlike `appIconHint`, this describes formats the
+                    webapp can open rather than the share-level icon hint.
+                  minItems: 1
+                  uniqueItems: true
+                  items:
+                    type: string
             ssh:
               type: object
               properties:
@@ -948,6 +961,9 @@ components:
                   - must-exchange-token
                 appName: HedgeDoc
                 appIconHint: text/markdown
+                mediaTypes:
+                  - text/markdown
+                  - text/html
               ssh:
                 accessTypes: ['datatx']
                 uri: extuser@cloud.example.org:/7c084226-d9a1-11e6-bf26-cec0c932ce01

--- a/spec.yaml
+++ b/spec.yaml
@@ -702,6 +702,7 @@ components:
               type: object
               required:
                 - uri
+                - sharedSecret
                 - permissions
               properties:
                 accessTypes:
@@ -779,6 +780,7 @@ components:
               type: object
               required:
                 - uri
+                - sharedSecret
                 - targets
                 - permissions
                 - requirements

--- a/spec.yaml
+++ b/spec.yaml
@@ -935,10 +935,9 @@ components:
                   - read
                 requirements:
                   - must-use-mfa
-                  - must-exchange-tokem                 
                   - must-exchange-token
               webapp:
-                uri: https://apps.example.org/codimd/7c084226-d9a1-11e6-bf26-cec0c932ce01
+                uri: https://apps.example.org/hedgedoc/7c084226-d9a1-11e6-bf26-cec0c932ce01
                 sharedSecret: hfiuhworzwnur98d3wjiwhr
                 targets:
                   - blank
@@ -947,7 +946,7 @@ components:
                 requirements:
                   - must-use-mfa
                   - must-exchange-token
-                appName: CodiMD
+                appName: HedgeDoc
                 appIconHint: text/markdown
               ssh:
                 accessTypes: ['datatx']

--- a/spec.yaml
+++ b/spec.yaml
@@ -409,27 +409,81 @@ components:
                       The top-level WebDAV path at this endpoint. In order to access
                       a remote shared resource, implementations SHOULD use this path
                       as a prefix (see sharing examples).
-                  webapp:
-                    type: string
+                  webdav-receive:
+                    type: object
                     description: >
-                      The top-level path for web apps at this endpoint. In order to
-                      access a remote web app, implementations SHOULD use this path
-                      as a prefix (see sharing examples).
+                      Implementations that support receiving WebDAV shares SHOULD
+                      advertise them here. Note though that older implementations MAY
+                      not support this property.
+                    properties:
+                      uri:
+                        type: string
+                        description: >
+                          This property signals that this endpoint is capable of
+                          receiving `webdav` shares with the given URI format.
+                          The value MUST be either `"absolute"` or `"relative"`.
+                        enum:
+                          - absolute
+                          - relative
+                  webapp:
+                    type: object
+                    description: >
+                      Implementations that support sending WebApp shares MUST advertise
+                      them here, with an empty object as value.
+                  webapp-receive:
+                    type: object
+                    description: >
+                      Implementations that support receiving WebApp shares MUST
+                      advertise them here.
+                    properties:
+                      targets:
+                        type: array
+                        description: >
+                          The target values this endpoint supports as receiver of
+                          a webapp share, similar to the target attributes in an
+                          HTML `<a>` tag.
+                          - "blank" signals that this endpoint supports opening
+                            the URI in a new window or tab.
+                          - "iframe" signals that this endpoint supports opening
+                            the URI in the same browsing context, within an iframe,
+                            and that it can set CORS headers.
+                          - "popup" signals that this endpoint supports opening
+                            the URI in an embedded popup window, and that it can
+                            set CORS headers.
+                        items:
+                          type: string
+                          enum:
+                            - blank
+                            - iframe
+                            - popup
                   ssh:
                     type: string
                     description: >
                       The top-level address in the form `host:port` of an endpoint
                       that supports ssh and scp with a public/private key based
                       authentication.
-                additionalProperties:
-                    type: string
+                  ssh-receive:
+                    type: object
                     description: >
-                      Any additional protocol supported for this resource type MAY
+                      Implementations that support receiving SSH shares MUST
+                      advertise them here, with an empty object as value.
+                additionalProperties:
+                    type: object
+                    description: >
+                      Any additional protocol supported for this resource type SHOULD
                       be advertised here, where the value MAY correspond to a top-level
-                      URI to be used for that protocol.
+                      URI to be used for that protocol, or any other relevant
+                      attribute required for that protocol. Similarly, additional
+                      receiving capabilities for custom protocols SHOULD be advertised.
                 example:
                   webdav: /remote/dav/ocm/
-                  webapp: /apps/ocm/
+                  webdav-receive: {
+                    "uri": "absolute"
+                  }
+                  webapp: {}
+                  webapp-receive: {
+                    "targets": ["blank", "iframe"]
+                  }
                   talk: /apps/spreed/api/
         capabilities:
           type: array
@@ -446,10 +500,9 @@ components:
               - invite-wayf
               - notifications
               - protocol-object
-              - webdav-uri
           example:
-            - webdav-uri
             - protocol-object
+            - invites
             - http-sig
         criteria:
           type: array
@@ -665,12 +718,12 @@ components:
                 uri:
                   type: string
                   description: >
-                    An URI to access the remote resource. The URI SHOULD be relative,
+                    An URI to access the remote resource. The URI MAY be relative,
                     such as a key or a UUID, in which case the prefix exposed by the
                     `/.well-known/ocm` endpoint MUST be used to access the resource, or
-                    it MAY be absolute, including a hostname. The latter is deprecated.
+                    it MAY be absolute, including a hostname.
                     In all cases, for a `folder` resource, the composed URI acts
-                    as the root path, such that other files located within it SHOULD
+                    as the root path, such that other files located within it MUST
                     be accessible by appending their relative path to that URI.
                 sharedSecret:
                   type: string
@@ -726,32 +779,63 @@ components:
                   description: >
                     An URI to a client-browsable view of the remote resource, such that
                     users may use a web application available at the sender site.
-                    The URI SHOULD be relative, such as a key or a UUID, in which case
-                    the prefix exposed by the `/.well-known/ocm` endpoint MUST be used
-                    to access the resource, or it MAY be absolute, including a hostname.
-                    Similar considerations as for the `webdav` case apply here.
-                    In all cases, for a `folder` resource, the composed URI acts
-                    as the root path, such that other files located within SHOULD
-                    be accessible by appending their relative path to that URI.
-                viewMode:
-                  type: string
-                  description: |
+                    The URI MUST be absolute, including a hostname. In case the
+                    underlying resource is a folder, the URI MUST act as a root path,
+                    such that files located within the folder are made accessible in
+                    the web app by appending their relative path to the URI.
+                targets:
+                  type: array
+                  description: >
+                    The target attribute values to be used when opening the URI, such
+                    as in an HTML `<a>` tag.If omitted, it defaults to `["blank"]`.
+                    - "blank" signals the recipient to open the URI in a new window or tab.
+                    - "iframe" signals the recipient to open the URI in the same browsing
+                      context, within an iframe. CORS headers MUST be properly set.
+                    - "popup" signals the recipient to open the URI in an embedded popup
+                      window. CORS headers MUST be properly set.
+                  items:
+                    type: string
+                    enum:
+                      - blank
+                      - iframe
+                      - popup
+                permissions:
+                  type: array
+                  description: >
                     The permissions granted to the sharee.
                     - `view` allows access to the web app in view-only mode.
                     - `read` allows read and download access via the web app.
                     - `write` allows full editing rights via the web app.
-                  enum:
-                    - view
-                    - read
-                    - write
+                    - `share` allows re-share rights on the resource. This only
+                      applies to web apps that provide a mechanism for re-sharing.
+                  items:
+                    type: string
+                    enum:
+                      - view
+                      - read
+                      - write
+                      - share
                 sharedSecret:
                   type: string
                   description: >
-                    An optional secret to be used to access the remote web app, such as
-                    a bearer token.  To prevent leaking it in logs it MUST NOT appear
-                    in any URI.  In a multi-protocol share scenario with WebDAV, the
-                    access requirements provided in the `webdav` part MUST apply for
-                    `webapp` accesses as well.
+                    A secret for accessing the remote web app, such as a bearer token.
+                    To give access to the remote app, the receiver MUST perform a HTTP
+                    POST request to the given URI, with the shared secret in a form field
+                    named `access_token`. To prevent leaking it in logs it MUST NOT appear
+                    in any URI. In a multi-protocol share scenario with WebDAV, the access
+                    requirements provided in the `webdav` part MUST apply for `webapp`
+                    accesses as well.
+                appName:
+                  type: string
+                  description: >
+                    An optional human-friendly name of the web application to be used
+                    in user interfaces when referring to this share.
+                appIcon:
+                  type: string
+                  description: >
+                    An optional URI to an icon representing the web application, to be
+                    used in user interfaces when referring to this share. The URI MUST
+                    be absolute, including a hostname.
             ssh:
               type: object
               properties:
@@ -801,16 +885,21 @@ components:
               name: multi
               webdav:
                 accessTypes: ['remote', 'datatx']
-                uri: 7c084226-d9a1-11e6-bf26-cec0c932ce01
+                uri: https://cloud.example.org/remote/dav/ocm/7c084226-d9a1-11e6-bf26-cec0c932ce01
                 sharedSecret: hfiuhworzwnur98d3wjiwhr
                 permissions:
                   - read
                 requirements:
                   - must-use-mfa
               webapp:
-                uri: 7c084226-d9a1-11e6-bf26-cec0c932ce01
+                uri: https://apps.example.org/codimd/7c084226-d9a1-11e6-bf26-cec0c932ce01
                 sharedSecret: hfiuhworzwnur98d3wjiwhr
-                viewMode: read
+                targets:
+                  - blank
+                permissions:
+                  - read
+                appName: CodiMD
+                appIcon: https://apps.example.org/assets/codimd-icon.png
               ssh:
                 accessTypes: ['datatx']
                 uri: extuser@cloud.example.org:/7c084226-d9a1-11e6-bf26-cec0c932ce01

--- a/spec.yaml
+++ b/spec.yaml
@@ -411,6 +411,8 @@ components:
                       as a prefix (see sharing examples).
                   webdav-receive:
                     type: object
+                    required:
+                      - uri
                     description: >
                       Implementations that support receiving WebDAV shares SHOULD
                       advertise them here. Note though that older implementations MAY
@@ -432,12 +434,15 @@ components:
                       them here, with an empty object as value.
                   webapp-receive:
                     type: object
+                    required:
+                      - targets
                     description: >
                       Implementations that support receiving WebApp shares MUST
                       advertise them here.
                     properties:
                       targets:
                         type: array
+                        minItems: 1
                         description: >
                           The ways this endpoint is able to present a webapp
                           share to the user when acting as receiver.
@@ -448,7 +453,8 @@ components:
                             current page.
                           - "iframe" signals that this endpoint supports
                             embedding the URI in an iframe within its own UI,
-                            and that it can set CORS headers.
+                            when the Sending Server allows framing by this
+                            receiver.
                         items:
                           type: string
                           enum:
@@ -467,7 +473,9 @@ components:
                       Implementations that support receiving SSH shares MUST
                       advertise them here, with an empty object as value.
                 additionalProperties:
-                    type: object
+                    oneOf:
+                      - type: string
+                      - type: object
                     description: >
                       Any additional protocol supported for this resource type SHOULD
                       be advertised here, where the value MAY correspond to a top-level
@@ -788,6 +796,7 @@ components:
                     the web app by appending their relative path to the URI.
                 targets:
                   type: array
+                  minItems: 1
                   description: >
                     How the recipient should present the URI to the user.
                     This array is REQUIRED and MUST NOT be empty: a webapp
@@ -796,7 +805,7 @@ components:
                     - "redirect" signals the recipient to navigate the browser to the URI,
                       replacing the current page.
                     - "iframe" signals the recipient to embed the URI in an iframe within
-                      its own UI. CORS headers MUST be properly set.
+                      its own UI, when the Sending Server allows framing by the recipient.
                   items:
                     type: string
                     enum:
@@ -805,6 +814,7 @@ components:
                       - iframe
                 permissions:
                   type: array
+                  minItems: 1
                   description: >
                     The permissions granted to the sharee. This array is
                     REQUIRED and MUST NOT be empty.
@@ -823,13 +833,15 @@ components:
                 sharedSecret:
                   type: string
                   description: >
-                    A secret for accessing the remote web app, such as a bearer token.
-                    To give access to the remote app, the receiver MUST perform a HTTP
-                    POST request to the given URI, with the shared secret in a form field
-                    named `access_token`. To prevent leaking it in logs it MUST NOT appear
-                    in any URI. In a multi-protocol share scenario with WebDAV, the access
-                    requirements provided in the `webdav` part MUST apply for `webapp`
-                    accesses as well.
+                    A secret for accessing the remote web app. To give access to the
+                    remote app, the receiver MUST first exchange this value at the
+                    Sending Server's `tokenEndPoint` using the Code Flow, then perform
+                    an HTTP POST request to the given URI with the resulting bearer
+                    token in a form field named `access_token`. The shared secret MUST
+                    NOT be exposed to the browser and MUST NOT appear in any URI. In a
+                    multi-protocol share scenario with WebDAV, the access requirements
+                    provided in the `webdav` part MUST apply for `webapp` accesses as
+                    well.
                 appName:
                   type: string
                   description: >
@@ -840,8 +852,11 @@ components:
                   description: >
                     An optional URI to an icon representing the web application, to be
                     used in user interfaces when referring to this share. An embedded
-                    data URI can be used. Alternatively, if a regular URI is used,
-                    it MUST be absolute, including a hostname.
+                    data URI MAY be used if it identifies an image resource.
+                    Alternatively, if a regular URI is used, it MUST be absolute,
+                    including a hostname. Receiving Servers MUST render the icon only
+                    in an inert image context and MAY reject unsupported or unsafe
+                    image types.
             ssh:
               type: object
               properties:

--- a/spec.yaml
+++ b/spec.yaml
@@ -447,10 +447,8 @@ components:
                           The ways this endpoint is able to present a webapp
                           share to the user when acting as receiver.
                           - "blank" signals that this endpoint supports opening
-                            the URI in a new window or tab.
-                          - "redirect" signals that this endpoint supports
-                            navigating the browser to the URI, replacing the
-                            current page.
+                            the URI in a new window or tab, or doing a full page
+                            redirect to the URI.
                           - "iframe" signals that this endpoint supports
                             embedding the URI in an iframe within its own UI,
                             when the Sending Server allows framing by this

--- a/spec.yaml
+++ b/spec.yaml
@@ -781,6 +781,7 @@ components:
                 - uri
                 - targets
                 - permissions
+                - requirements
               properties:
                 uri:
                   type: string
@@ -825,6 +826,27 @@ components:
                       - read
                       - write
                       - share
+                requirements:
+                  type: array
+                  minItems: 1
+                  description: >
+                    The requirements that the sharee MUST fulfill to access the
+                    resource. This array is REQUIRED and MUST at least include
+                    `must-exchange-token`. If multiple protocols are present in
+                    the share payload, the requirements for the different
+                    protocols MUST agree.
+                    - `must-use-mfa` requires the user accessing the resource to be
+                      MFA-authenticated. This requirement MAY be used if the
+                      recipient provider exposes the `enforce-mfa` capability.
+                    - `must-exchange-token` requires the recipient to exchange the given
+                      `sharedSecret` via a signed HTTPS request to tokenEndPoint at the
+                      Sending Server, in order to get a short-lived token to be used
+                      for subsequent access [RFC6749].
+                  items:
+                    type: string
+                    enum:
+                      - must-use-mfa
+                      - must-exchange-token
                 sharedSecret:
                   type: string
                   description: >
@@ -832,7 +854,10 @@ components:
                     remote app, the receiver MUST first exchange this value at the
                     Sending Server's `tokenEndPoint` using the Code Flow, then perform
                     an HTTP POST request to the given URI with the resulting bearer
-                    token in a form field named `access_token`. The shared secret MUST
+                    token in a form field named `access_token`, along with another form
+                    field named `expired_session_redirect_uri` that represents the
+                    location where the receiving server can handle refresh of tokens.
+                    The shared secret MUST
                     NOT be exposed to the browser and MUST NOT appear in any URI. In a
                     multi-protocol share scenario with WebDAV, the access requirements
                     provided in the `webdav` part MUST apply for `webapp` accesses as
@@ -908,6 +933,7 @@ components:
                   - read
                 requirements:
                   - must-use-mfa
+                  - must-exchange-token
               webapp:
                 uri: https://apps.example.org/codimd/7c084226-d9a1-11e6-bf26-cec0c932ce01
                 sharedSecret: hfiuhworzwnur98d3wjiwhr
@@ -915,8 +941,11 @@ components:
                   - blank
                 permissions:
                   - read
+                requirements:
+                  - must-use-mfa
+                  - must-exchange-token
                 appName: CodiMD
-                appIcon: https://apps.example.org/assets/codimd-icon.png
+                appIconHint: text/markdown
               ssh:
                 accessTypes: ['datatx']
                 uri: extuser@cloud.example.org:/7c084226-d9a1-11e6-bf26-cec0c932ce01


### PR DESCRIPTION
I also normalized the vocabulary for targets to blank, redirect and iframe, as there were some inconsistencies using popup before. Both permissions and targets are required, so as to make everything explicit.