### PR TITLE
Removed the already deprecated draft-cavage pubkey

### DIFF
--- a/IETF-RFC.md
+++ b/IETF-RFC.md
@@ -791,8 +791,6 @@ contain the following information about its OCM API:
   - `"must-invite"` - an invite MUST have been exchanged between the
   sender and the receiver before a Share Creation Notification can be
   sent
-* DEPRECATED: publicKey (object) - Use public keys at
-  `/.well-known/jwks.json` instead for RFC 9421 support.
 * OPTIONAL: inviteAcceptDialog (string) - URL path of a web page where
   a user can accept an invite, when query parameters `"token"` and
   `"providerDomain"` are provided.  Implementations that offer the
@@ -2000,7 +1998,6 @@ that section.
             | - endPoint            |
             | - inviteAcceptDialog  |
             | - provider            |
-            | - publicKey           |
             | - tokenEndPoint       |
             | - ...                 |
             +-----------------------+
@@ -2059,7 +2056,6 @@ that section.
 * __enabled__: Boolean indicating if OCM service is active
 * __endPoint__: Base URI for OCM API endpoints
 * __provider__: Friendly branding name
-* __publicKey__: Optional public key for HTTP signatures
 * __resourceTypes__: Array of supported resource types with protocols
 
 ## Share

--- a/schemas/ocm-discovery.json
+++ b/schemas/ocm-discovery.json
@@ -34,9 +34,6 @@
         "type": "string"
       }
     },
-    "publicKey": {
-      "$ref": "#/$defs/publicKey"
-    },
     "inviteAcceptDialog": {
       "type": "string",
       "format": "uri"
@@ -118,18 +115,6 @@
           { "type": "object" }
         ]
       }
-    },
-    "publicKey": {
-      "type": "object",
-      "properties": {
-        "keyId": {
-          "type": "string"
-        },
-        "publicKeyPem": {
-          "type": "string"
-        }
-      },
-      "required": ["keyId", "publicKeyPem"]
     }
   }
 }

--- a/spec.yaml
+++ b/spec.yaml
@@ -526,30 +526,6 @@ components:
           example:
             - allowlist
             - must-invite
-        publicKey:
-          type: object
-          deprecated: true
-          description: >
-            DEPRECATED: Use public keys from /.well-known/jwks.json
-            instead for RFC 9421 support.
-            Legacy field for draft-cavage HTTP Signatures (RSA only).
-            Maintained for backward compatibility with existing deployments.
-            The signatory is optional but it MUST contain `keyId` and `publicKeyPem`.
-          properties:
-            keyId:
-              type: string
-              description: >
-                unique id of the key in URI format. The hostname set the origin
-                of the request and MUST be identical to the current discovery endpoint.
-              example: https://cloud.example.org/ocm#signature
-            publicKeyPem:
-              type: string
-              description: |
-                PEM-encoded RSA public key for draft-cavage signatures.
-              example: |
-                -----BEGIN PUBLIC KEY-----
-                MII...QDD
-                -----END PUBLIC KEY-----
         tokenEndPoint:
           type: string
           format: uri


### PR DESCRIPTION
This is a "maintenance" PR: as in Nextcloud we now have a RFC-compliant implementation, there's no need to carry over the deprecated draft-cavage public key. This removes it completely.