### PR TITLE
Add IANA registries

### DIFF
--- a/IETF-OCM-MLS.md
+++ b/IETF-OCM-MLS.md
@@ -51,9 +51,9 @@ capabilities for resources shared with federated groups.
 
 Open Cloud Mesh [OCM] currently supports sharing resources with
 individual users across federated servers and with groups on a single
-server.  [OCM] also defines a `shareType` of `"federation"` but does
-not further specify its semantics.  This document gives `"federation"`
-concrete semantics: a federated group identified by an
+server.  This document defines a new `shareType`, `"federation"`, and
+registers it in the "OCM Share Types" registry defined by [OCM].  A
+`"federation"` share is addressed to a federated group identified by an
 OCM Address such as `research-group@receiver.example.org` whose
 membership spans multiple OCM servers, with group state managed through
 the MLS [RFC9420] epoch mechanism.
@@ -1848,6 +1848,36 @@ the "providerId" field (see {{mls-notification-types}}):
    | MLS_APPLICATION   | Group | active | This document |
    | MLS_REJOIN        | Group | active | This document |
    +===================+=======+========+===============+
+~~~
+
+The following entry is to be registered in the "OCM Share Types"
+registry defined in [OCM], within the "Open Cloud Mesh (OCM)
+Parameters" group.  This document is the registering specification for
+the "federation" share type:
+
+~~~
+   +============+===============+
+   | Share Type | Reference     |
+   +============+===============+
+   | federation | This document |
+   +============+===============+
+~~~
+
+The following entries are to be registered in the "OCM Share Payloads"
+registry defined in [OCM], within the "Open Cloud Mesh (OCM)
+Parameters" group.  They extend the existing "webdav", "webapp", and
+"ssh" protocols to the "federation" share type; the wire format of the
+share payload for these combinations is completely specified by this
+document together with [OCM] (see {{share-creation}}).  These
+registrations do not modify the protocols' own registrations:
+
+~~~
+   +===============+============+=====================+===============+
+   | Resource Type | Share Type | Protocols           | Reference     |
+   +===============+============+=====================+===============+
+   | file          | federation | webdav, webapp, ssh | This document |
+   | folder        | federation | webdav, webapp, ssh | This document |
+   +===============+============+=====================+===============+
 ~~~
 
 # Open Issues

--- a/IETF-OCM-MLS.md
+++ b/IETF-OCM-MLS.md
@@ -51,9 +51,9 @@ capabilities for resources shared with federated groups.
 
 Open Cloud Mesh [OCM] currently supports sharing resources with
 individual users across federated servers and with groups on a single
-server.  The specification also defines a `shareType` of `"federation"`
-but does not further specify its semantics.  This document gives
-`"federation"` a concrete definition: a federated group identified by an
+server.  [OCM] also defines a `shareType` of `"federation"` but does
+not further specify its semantics.  This document gives `"federation"`
+concrete semantics: a federated group identified by an
 OCM Address such as `research-group@receiver.example.org` whose
 membership spans multiple OCM servers, with group state managed through
 the MLS [RFC9420] epoch mechanism.
@@ -1850,23 +1850,21 @@ the "providerId" field (see {{mls-notification-types}}):
    +===================+=======+========+===============+
 ~~~
 
-The following share payload tuples are to be registered in the "OCM
-Share Payloads" registry defined in [OCM], within the "Open Cloud Mesh
-(OCM) Parameters" group.  The complete share payload for federated
-shares is specified by this document together with [OCM] (see
-{{share-creation}}):
+The following entries are to be registered in the "OCM Share Payloads"
+registry defined in [OCM], within the "Open Cloud Mesh (OCM)
+Parameters" group.  They extend the existing "webdav", "webapp", and
+"ssh" protocols to the "federation" share type; the wire format of the
+share payload for these combinations is completely specified by this
+document together with [OCM] (see {{share-creation}}).  These
+registrations do not modify the protocols' own registrations:
 
 ~~~
-   +===============+============+==========+===============+
-   | Resource Type | Share Type | Protocol | Reference     |
-   +===============+============+==========+===============+
-   | file          | federation | webdav   | This document |
-   | file          | federation | webapp   | This document |
-   | file          | federation | ssh      | This document |
-   | folder        | federation | webdav   | This document |
-   | folder        | federation | webapp   | This document |
-   | folder        | federation | ssh      | This document |
-   +===============+============+==========+===============+
+   +===============+============+=====================+===============+
+   | Resource Type | Share Type | Protocols           | Reference     |
+   +===============+============+=====================+===============+
+   | file          | federation | webdav, webapp, ssh | This document |
+   | folder        | federation | webdav, webapp, ssh | This document |
+   +===============+============+=====================+===============+
 ~~~
 
 # Open Issues

--- a/IETF-OCM-MLS.md
+++ b/IETF-OCM-MLS.md
@@ -641,7 +641,7 @@ takeover time T MAY be generous, for example several hours.  Loose time
 synchronisation between servers is sufficient and is already assumed by
 MLS for leaf node lifetimes ([RFC9420] Section 7.2).
 
-## MLS Notification Types
+## MLS Notification Types {#mls-notification-types}
 
 All MLS group lifecycle messages are sent as OCM Notifications to
 `<endPoint>/notifications` using HTTP POST with `Content-Type:
@@ -1832,6 +1832,42 @@ defined in [RFC9420] Section 17.3:
 - Message(s): GC
 - Recommended: N
 - Reference: This document
+
+The following notification types are to be registered in the "OCM
+Notification Types" registry defined in [OCM], within the "Open Cloud
+Mesh (OCM) Parameters" group.  All are group-scoped and therefore omit
+the "providerId" field (see {{mls-notification-types}}):
+
+~~~
+   +===================+=======+========+===============+
+   | Notification Type | Scope | Status | Reference     |
+   +===================+=======+========+===============+
+   | MLS_WELCOME       | Group | active | This document |
+   | MLS_PROPOSAL      | Group | active | This document |
+   | MLS_COMMIT        | Group | active | This document |
+   | MLS_APPLICATION   | Group | active | This document |
+   | MLS_REJOIN        | Group | active | This document |
+   +===================+=======+========+===============+
+~~~
+
+The following share payload tuples are to be registered in the "OCM
+Share Payloads" registry defined in [OCM], within the "Open Cloud Mesh
+(OCM) Parameters" group.  The complete share payload for federated
+shares is specified by this document together with [OCM] (see
+{{share-creation}}):
+
+~~~
+   +===============+============+==========+===============+
+   | Resource Type | Share Type | Protocol | Reference     |
+   +===============+============+==========+===============+
+   | file          | federation | webdav   | This document |
+   | file          | federation | webapp   | This document |
+   | file          | federation | ssh      | This document |
+   | folder        | federation | webdav   | This document |
+   | folder        | federation | webapp   | This document |
+   | folder        | federation | ssh      | This document |
+   +===============+============+==========+===============+
+~~~
 
 # Open Issues
 

--- a/IETF-OCM-MLS.md
+++ b/IETF-OCM-MLS.md
@@ -1850,23 +1850,6 @@ the "providerId" field (see {{mls-notification-types}}):
    +===================+=======+========+===============+
 ~~~
 
-The following entries are to be registered in the "OCM Share Payloads"
-registry defined in [OCM], within the "Open Cloud Mesh (OCM)
-Parameters" group.  They extend the existing "webdav", "webapp", and
-"ssh" protocols to the "federation" share type; the wire format of the
-share payload for these combinations is completely specified by this
-document together with [OCM] (see {{share-creation}}).  These
-registrations do not modify the protocols' own registrations:
-
-~~~
-   +===============+============+=====================+===============+
-   | Resource Type | Share Type | Protocols           | Reference     |
-   +===============+============+=====================+===============+
-   | file          | federation | webdav, webapp, ssh | This document |
-   | folder        | federation | webdav, webapp, ssh | This document |
-   +===============+============+=====================+===============+
-~~~
-
 # Open Issues
 
 This section collects open design issues and shall be removed before

--- a/IETF-OCM.md
+++ b/IETF-OCM.md
@@ -834,16 +834,19 @@ If the Receiving Server does not advertise `must-exchange-token` in its
 `criteria`, the Sending Server MAY still include `must-exchange-token`
 voluntarily.
 
-The Sending Server MUST NOT create a share for a combination of
+The Sending Server SHOULD NOT create a share for a combination of
 resource type, share type, and protocol that the Receiving Server does
 not advertise in its Discovery response.  Specifically, for the
 share's `resourceType` and `shareType`, and for each protocol offered
 in the `protocol` object, the Receiving Server's `resourceTypes` array
-MUST contain an entry whose `name` equals the `resourceType`, whose
+SHOULD contain an entry whose `name` equals the `resourceType`, whose
 `shareTypes` array contains the `shareType`, and whose `protocols`
 object contains that protocol's `-receive` property.  Each such
 combination corresponds to an entry in the "OCM Share Payloads"
 registry (see [IANA Considerations](#iana-considerations)).
+For backwards compatibility reasons, the Sending Server MAY still send
+a share with the `file, user, webdav` combination if the Receiving
+server does not advertise it, as it MAY be assumed to be supported.
 
 When the notification includes `protocol.webapp`, the Sending Server
 MUST expose the `exchange-token` capability and a `tokenEndPoint`,
@@ -1669,34 +1672,31 @@ shape of the "protocol" details object.
 
 The registered combinations are a constrained subset, not the full
 Cartesian product of those three registries, even though for the
-initial content the subset and the Cartesian product is the same thing.
-However, in other cases that file sharing, a protocol may only be
+initial content the subset and the Cartesian product correspond.
+However, in other cases beyond file sharing, a protocol may only be
 meaningful for certain resource types.  A calendar event, for example,
 is usually shared over CalDAV or JMAP, not over ssh.  Other
 specifications MAY register additional combinations, including ones
 that extend an already-registered protocol to a new resource type or
 share type; doing so does not modify that protocol's own registration.
-The federation combinations are registered in this way by [OCM-MLS].
 If someone wants to specify how to share calendar events over ssh in an
 interoperable way, they can do so using this very mechanism.
-
-A Sending Server MUST NOT send a share for a combination that the
-Receiving Server does not advertise in Discovery (see
-[Share Creation Notification](#share-creation-notification)).
 
    Registration Policy: Specification Required [RFC8126]
 
    Initial Contents:
 
 ~~~
-   +===============+============+=====================+===============+
-   | Resource Type | Share Type | Protocols           | Reference     |
-   +===============+============+=====================+===============+
-   | file          | user       | webdav, webapp, ssh | This document |
-   | file          | group      | webdav, webapp, ssh | This document |
-   | folder        | user       | webdav, webapp, ssh | This document |
-   | folder        | group      | webdav, webapp, ssh | This document |
-   +===============+============+=====================+===============+
+   +===========+============+=====================+===================+
+   | Res. Type | Share Type | Protocols           | Reference         |
+   +===========+============+=====================+===================+
+   | file      | user       | webdav, webapp, ssh | This document     |
+   | file      | group      | webdav, webapp, ssh | This document     |
+   | file      | federation | webdav, webapp, ssh | This doc, OCM-MLS |
+   | folder    | user       | webdav, webapp, ssh | This document     |
+   | folder    | group      | webdav, webapp, ssh | This document     |
+   | folder    | federation | webdav, webapp, ssh | This doc, OCM-MLS |
+   +===========+============+=====================+===================+
 ~~~
 
 ## OCM Notification Types Registry

--- a/IETF-OCM.md
+++ b/IETF-OCM.md
@@ -681,8 +681,9 @@ contain the following information about its OCM API:
     object per given `name`.
   - shareTypes (array of string) -
     The supported recipient share types.  MUST contain
-    `"user"` at a minimum, plus optionally `"group"` and
-    `"federation"`.
+    `"user"` at a minimum, plus optionally `"group"` or any
+    other value registered in the "OCM Share Types" registry
+    (see [IANA Considerations](#iana-considerations)).
     Example: `["user"]`
   - protocols (object) - The supported protocols for accessing Shared
     Resources of this type.  Implementations that offer `file`
@@ -862,10 +863,9 @@ described in [OCM-IP].
 ## Fields
 
 * REQUIRED shareWith (string)
-  OCM Address of the user, group or federation the provider
-  wants to share the Resource with.  This MUST be known
-  in advance, either via a previous Invitation or through
-  other means.
+  OCM Address of the user or group the provider wants to share the
+  Resource with.  This MUST be known in advance, either via a previous
+  Invitation or through other means.
   Example: "51dc30ddc473d43a6011e9ebba6ca770@cloud.example.org"
 * REQUIRED name (string)
   Name of the Resource (file or folder).
@@ -894,23 +894,19 @@ described in [OCM-IP].
   Display name of the user that wants to share the Resource
   Example: "John Doe"
 * REQUIRED shareType (string)
-  SHOULD have a value of "user", "group", or "federation", to
-  indicate that the first part of the `shareWith` OCM Address refers
-  to a Receiving Party who is a single user of the Receiving Server,
-  a group of users at the Receiving Server, or a group of users that
-  spans multiple OCM Servers belonging to a federation as exposed by
-  a Directory Service, including at least one user at the Receiving
-  Server.
-  In the federation case, OCM Servers MAY resolve the actual
-  recipients by either querying external AAI systems, or exchanging
-  the groups' metadata between themselves.  For the latter, the
-  RECOMMENDED implementation is based on the MLS protocol and it is
-  described in [OCM-MLS].
-  Alternatively, the Receiving Server MAY hold the federated groups'
-  metadata and act as an OCM proxy, forwarding the OCM requests to
-  the actual members of the federation.
-  Registered values are listed in the "OCM Share Types" registry
-  (see [IANA Considerations](#iana-considerations)).
+  SHOULD have a value of "user" or "group", to indicate that the first
+  part of the `shareWith` OCM Address refers to a Receiving Party who
+  is a single user of the Receiving Server, or a group of users at the
+  Receiving Server.  Other values MAY be used provided they are
+  registered in the "OCM Share Types" registry (see
+  [IANA Considerations](#iana-considerations)); for example, [OCM-MLS]
+  registers the "federation" share type for a group of users that
+  spans multiple OCM Servers.
+  The Sending Server SHOULD only use a `shareType` that the Receiving
+  Server advertises for the share's `resourceType` in its Discovery
+  response, i.e. one listed in the `shareTypes` array of the matching
+  `resourceTypes` entry (see
+  [Share Creation Notification](#share-creation-notification)).
 * REQUIRED resourceType (string)
   Resource type (file, folder, calendar, contact, ...).  If the
   Resource is a folder, implementations SHOULD advertise it as
@@ -1163,11 +1159,10 @@ been shared, the Receiving Party MAY make an HTTP POST request
 ## Fields
 
 * REQUIRED owner (string)
-  OCM Address of the user who will be requested to share
-  the resource.
+  OCM Address of the user who will be requested to share the resource.
 * REQUIRED shareWith (string)
-  OCM Address of the user, group or federation that wants to
-  receive a share of the resource.
+  OCM Address of the user or group that wants to receive a share of
+  the resource.
   Example: "51dc30ddc473d43a6011e9ebba6ca770@cloud.example.org"
 * REQUIRED share (string)
   A unique identifier for the resource.
@@ -1632,6 +1627,9 @@ IANA is requested to create the "OCM Share Types" registry in the
 type that MAY appear in the "shareTypes" array advertised by the
 [OCM API Discovery](#ocm-api-discovery) endpoint or in the "shareType"
 field of a [Share Creation Notification](#share-creation-notification).
+This document registers only the "user" and "group" share types; other
+specifications MAY register additional share types in this registry.
+The "federation" share type, for example, is registered by [OCM-MLS].
 
    Registration Policy: Specification Required [RFC8126]
 
@@ -1643,7 +1641,6 @@ field of a [Share Creation Notification](#share-creation-notification).
    +============+===============+
    | user       | This document |
    | group      | This document |
-   | federation | This document |
    +============+===============+
 ~~~
 
@@ -1679,6 +1676,7 @@ is usually shared over CalDAV or JMAP, not over ssh.  Other
 specifications MAY register additional combinations, including ones
 that extend an already-registered protocol to a new resource type or
 share type; doing so does not modify that protocol's own registration.
+The federation combinations are registered in this way by [OCM-MLS].
 If someone wants to specify how to share calendar events over ssh in an
 interoperable way, they can do so using this very mechanism.
 
@@ -1687,16 +1685,14 @@ interoperable way, they can do so using this very mechanism.
    Initial Contents:
 
 ~~~
-   +===========+============+=====================+===================+
-   | Res. Type | Share Type | Protocols           | Reference         |
-   +===========+============+=====================+===================+
-   | file      | user       | webdav, webapp, ssh | This document     |
-   | file      | group      | webdav, webapp, ssh | This document     |
-   | file      | federation | webdav, webapp, ssh | This doc, OCM-MLS |
-   | folder    | user       | webdav, webapp, ssh | This document     |
-   | folder    | group      | webdav, webapp, ssh | This document     |
-   | folder    | federation | webdav, webapp, ssh | This doc, OCM-MLS |
-   +===========+============+=====================+===================+
+   +===============+============+=====================+===============+
+   | Resource Type | Share Type | Protocols           | Reference     |
+   +===============+============+=====================+===============+
+   | file          | user       | webdav, webapp, ssh | This document |
+   | file          | group      | webdav, webapp, ssh | This document |
+   | folder        | user       | webdav, webapp, ssh | This document |
+   | folder        | group      | webdav, webapp, ssh | This document |
+   +===============+============+=====================+===============+
 ~~~
 
 ## OCM Notification Types Registry
@@ -2320,7 +2316,7 @@ from a Sending Party to a Receiving Party.
                     must-exchange-token)
 * __resourceType__: Type of resource (file, folder, calendar, etc.)
 * __sender__: OCM Address of the party creating the Share
-* __shareType__: Type of recipient (user, group, federation)
+* __shareType__: Type of recipient (user, group, ...)
 * __shareWith__: OCM Address of the Receiving Party
 * __state__: Current state of the Share (accepted, pending, deleted)
 

--- a/IETF-OCM.md
+++ b/IETF-OCM.md
@@ -1647,42 +1647,56 @@ field of a [Share Creation Notification](#share-creation-notification).
 ## OCM Share Payloads Registry
 
 IANA is requested to create the "OCM Share Payloads" registry in the
-"Open Cloud Mesh (OCM) Parameters" group.  Each entry records a
-combination of resource type, share type, and protocol for which a
-complete share payload is specified, together with a reference to the
-document that specifies that payload.
+"Open Cloud Mesh (OCM) Parameters" group.  Whereas the "OCM Resource
+Types", "OCM Share Types", and "OCM Protocols" registries record the
+identifiers advertised in Discovery, this registry records the
+wire format of the share payload itself: each entry binds a meaningful
+combination of resource type, share type, and one or more protocols to
+the document that completely specifies the wire format of the
+[Share Creation Notification](#share-creation-notification) for that
+combination.  Two implementations may agree on the Discovery
+identifiers and still fail to interoperate if the fields and structure
+of the payload are left unspecified; this registry is where that wire
+format is pinned down.
 
-The values in the "Resource Type", "Share Type", and "Protocol"
-columns MUST already appear in the "OCM Resource Types", "OCM Share
-Types", and "OCM Protocols" registries respectively.  For this
-registry, the Designated Expert MUST verify that the referenced
-specification completely specifies the share payload for the tuple,
-including every required and optional field and the full shape of the
-"protocol" details object.  A Sending Server MUST NOT send a share for
-a tuple that is not advertised by the Receiving Server in Discovery
-(see [Share Creation Notification](#share-creation-notification)).
+Every value in the "Resource Type", "Share Type", and "Protocols"
+columns MUST already appear in the corresponding "OCM Resource Types",
+"OCM Share Types", or "OCM Protocols" registry.  For each entry,
+the Designated Expert MUST verify that the referenced specification
+completely specifies the wire format of the share payload for the
+combination, including every required and optional field and the full
+shape of the "protocol" details object.
+
+The registered combinations are a constrained subset, not the full
+Cartesian product of those three registries, even though for the
+initial content the subset and the Cartesian product is the same thing.
+However, in other cases that file sharing, a protocol may only be
+meaningful for certain resource types.  A calendar event, for example,
+is usually shared over CalDAV or JMAP, not over ssh.  Other
+specifications MAY register additional combinations, including ones
+that extend an already-registered protocol to a new resource type or
+share type; doing so does not modify that protocol's own registration.
+The federation combinations are registered in this way by [OCM-MLS].
+If someone wants to specify how to share calendar events over ssh in an
+interoperable way, they can do so using this very mechanism.
+
+A Sending Server MUST NOT send a share for a combination that the
+Receiving Server does not advertise in Discovery (see
+[Share Creation Notification](#share-creation-notification)).
 
    Registration Policy: Specification Required [RFC8126]
 
    Initial Contents:
 
 ~~~
-   +===============+============+==========+===============+
-   | Resource Type | Share Type | Protocol | Reference     |
-   +===============+============+==========+===============+
-   | file          | user       | webdav   | This document |
-   | file          | user       | webapp   | This document |
-   | file          | user       | ssh      | This document |
-   | file          | group      | webdav   | This document |
-   | file          | group      | webapp   | This document |
-   | file          | group      | ssh      | This document |
-   | folder        | user       | webdav   | This document |
-   | folder        | user       | webapp   | This document |
-   | folder        | user       | ssh      | This document |
-   | folder        | group      | webdav   | This document |
-   | folder        | group      | webapp   | This document |
-   | folder        | group      | ssh      | This document |
-   +===============+============+==========+===============+
+   +===============+============+=====================+===============+
+   | Resource Type | Share Type | Protocols           | Reference     |
+   +===============+============+=====================+===============+
+   | file          | user       | webdav, webapp, ssh | This document |
+   | file          | group      | webdav, webapp, ssh | This document |
+   | folder        | user       | webdav, webapp, ssh | This document |
+   | folder        | group      | webdav, webapp, ssh | This document |
+   +===============+============+=====================+===============+
 ~~~
 
 ## OCM Notification Types Registry

--- a/IETF-OCM.md
+++ b/IETF-OCM.md
@@ -673,8 +673,8 @@ contain the following information about its OCM API:
   Server role, with their access protocols.  Each item in this list
   MUST itself be an object containing the following fields:
   - name (string) - A supported resource type, such as file, calendar,
-    calendar, contact, etc.  Implementations MUST offer support for at
-    least one resource type: `file` is the commonly supported one, and
+    contact, etc.  Implementations MUST offer support for at least one
+    resource type: `file` is the commonly supported one, and
     other values are to be registered in the "OCM Resource Types"
     registry (see [IANA Considerations](#iana-considerations)).
     Each resource type is identified by its `name`: the list MUST NOT

--- a/IETF-OCM.md
+++ b/IETF-OCM.md
@@ -672,13 +672,13 @@ contain the following information about its OCM API:
   server supports in both the Sending Server role and the Receiving
   Server role, with their access protocols.  Each item in this list
   MUST itself be an object containing the following fields:
-  - name (string) - A supported resource type (file, calendar,
-    contact, ...).
-    Implementations MUST offer support for at least one
-    resource type, where `file` is the commonly supported
-    one.  Each resource type is identified by its `name`:
-    the list MUST NOT contain more than one resource type
-    object per given `name`.
+  - name (string) - A supported resource type, such as file, calendar,
+    calendar, contact, etc.  Implementations MUST offer support for at
+    least one resource type: `file` is the commonly supported one, and
+    other values are to be registered in the "OCM Resource Types"
+    registry (see [IANA Considerations](#iana-considerations)).
+    Each resource type is identified by its `name`: the list MUST NOT
+    contain more than one resource type object per given `name`.
   - shareTypes (array of string) -
     The supported recipient share types.  MUST contain
     `"user"` at a minimum, plus optionally `"group"` or any
@@ -734,11 +734,13 @@ contain the following information about its OCM API:
       key based authentication.
     - ssh-receive (object) - Advertised, as an empty object, by
       implementations that support receiving SSH shares.
-    - Any additional protocol supported for this Resource type MAY be
-      advertised here, where the value MAY correspond to
-      a top-level URI to be used for that protocol.  Similarly,
-      additional receiving capabilities for custom protocols SHOULD
-      be advertised using a `-receive` suffixed property.
+    - Any additional protocol supported for this Resource type SHOULD be
+      advertised here, where the value MAY correspond to a top-level
+      URI to be used for that protocol.  Similarly, additional receiving
+      capabilities for custom protocols SHOULD be advertised using a
+      `-receive` suffixed property.  Additional protocols are to be
+      registered in the "OCM Protocols" registry (see
+      [IANA Considerations](#iana-considerations)).
 * OPTIONAL: capabilities (array of string) - The optional capabilities
   supported by this OCM Server.
   As implementations MUST accept Share Creation Notifications
@@ -2316,7 +2318,7 @@ from a Sending Party to a Receiving Party.
                     must-exchange-token)
 * __resourceType__: Type of resource (file, folder, calendar, etc.)
 * __sender__: OCM Address of the party creating the Share
-* __shareType__: Type of recipient (user, group, ...)
+* __shareType__: Type of recipient (user, group, etc.)
 * __shareWith__: OCM Address of the Receiving Party
 * __state__: Current state of the Share (accepted, pending, deleted)
 

--- a/IETF-OCM.md
+++ b/IETF-OCM.md
@@ -834,6 +834,17 @@ If the Receiving Server does not advertise `must-exchange-token` in its
 `criteria`, the Sending Server MAY still include `must-exchange-token`
 voluntarily.
 
+The Sending Server MUST NOT create a share for a combination of
+resource type, share type, and protocol that the Receiving Server does
+not advertise in its Discovery response.  Specifically, for the
+share's `resourceType` and `shareType`, and for each protocol offered
+in the `protocol` object, the Receiving Server's `resourceTypes` array
+MUST contain an entry whose `name` equals the `resourceType`, whose
+`shareTypes` array contains the `shareType`, and whose `protocols`
+object contains that protocol's `-receive` property.  Each such
+combination corresponds to an entry in the "OCM Share Payloads"
+registry (see [IANA Considerations](#iana-considerations)).
+
 When the notification includes `protocol.webapp`, the Sending Server
 MUST expose the `exchange-token` capability and a `tokenEndPoint`,
 because WebApp access requires the Receiving Server to exchange
@@ -895,11 +906,15 @@ described in [OCM-IP].
   Alternatively, the Receiving Server MAY hold the federated groups'
   metadata and act as an OCM proxy, forwarding the OCM requests to
   the actual members of the federation.
+  Registered values are listed in the "OCM Share Types" registry
+  (see [IANA Considerations](#iana-considerations)).
 * REQUIRED resourceType (string)
   Resource type (file, folder, calendar, contact, ...).  If the
   Resource is a folder, implementations SHOULD advertise it as
   `folder` rather than `file`, in order to streamline the processing
   by the Receiving Server.
+  Registered values are listed in the "OCM Resource Types" registry
+  (see [IANA Considerations](#iana-considerations)).
 * OPTIONAL expiration (integer)
   The expiration time for the OCM share, in seconds
   of UTC time since Unix epoch.  If omitted, it is assumed that the
@@ -913,6 +928,10 @@ described in [OCM-IP].
   - `webapp`, to access remote web applications.
   - `ssh`, to access the data via a public/private key pair.
   Other custom protocols might be added in the future.
+  Registered protocol values are listed in the "OCM Protocols"
+  registry, and the valid resource-type/share-type/protocol
+  combinations in the "OCM Share Payloads" registry (see
+  [IANA Considerations](#iana-considerations)).
   In case a single protocol is offered, there are three ways to
   specify this object:
   Option 1: Set the `name` field to the name of the protocol,
@@ -1178,6 +1197,8 @@ Receiving Server MAY make a HTTP POST request
   Notification it MUST be one of:
   - 'SHARE_ACCEPTED'
   - 'SHARE_DECLINED'
+  Registered values are listed in the "OCM Notification Types"
+  registry (see [IANA Considerations](#iana-considerations)).
 * REQUIRED providerId (string) - copied from the Share Creation
   Notification for the Share this notification is about
 * OPTIONAL resourceType (string) - copied from the Share Creation
@@ -1535,6 +1556,164 @@ Values" registry (using the template from [RFC9553]).
    |--------------|------------------------------------------|
 ~~~
 
+## Open Cloud Mesh Parameters Registry Group
+
+IANA is requested to create a new registry group titled "Open Cloud
+Mesh (OCM) Parameters", containing the registries defined in the
+following subsections.  Unless stated otherwise, the registration
+policy for each registry in this group is "Specification Required"
+[RFC8126].  The Designated Expert SHOULD verify that a requested entry
+is documented in a stable, publicly available specification and that it
+does not duplicate an existing entry.
+
+## OCM Resource Types Registry
+
+IANA is requested to create the "OCM Resource Types" registry in the
+"Open Cloud Mesh (OCM) Parameters" group.  This registry records the
+resource type values used both in the "resourceType" field of a
+[Share Creation Notification](#share-creation-notification) and in the
+"name" field of each entry in the "resourceTypes" array advertised by
+the [OCM API Discovery](#ocm-api-discovery) endpoint.
+
+   Registration Policy: Specification Required [RFC8126]
+
+   Initial Contents:
+
+~~~
+   +===============+=====================+===============+
+   | Resource Type | Description         | Reference     |
+   +===============+=====================+===============+
+   | file          | A single file       | This document |
+   | folder        | A folder/collection | This document |
+   +===============+=====================+===============+
+~~~
+
+## OCM Protocols Registry
+
+IANA is requested to create the "OCM Protocols" registry in the "Open
+Cloud Mesh (OCM) Parameters" group.  Each entry records a protocol
+property name that MAY appear in the "protocols" object advertised by
+the [OCM API Discovery](#ocm-api-discovery) endpoint or in the
+"protocol" object of a
+[Share Creation Notification](#share-creation-notification).
+
+A property whose "Role" is "send" (e.g. "webdav") advertises support
+for the Sending Server role in Discovery and is the value used in the
+share "protocol" object.  Its "-receive" suffixed counterpart (e.g.
+"webdav-receive"), whose "Role" is "receive", advertises support for
+the Receiving Server role in Discovery.  Which protocols MAY be used
+for a given resource type and share type is governed by the
+[OCM Share Payloads](#ocm-share-payloads-registry) registry.
+
+   Registration Policy: Specification Required [RFC8126]
+
+   Initial Contents:
+
+~~~
+   +================+=========+===============+
+   | Property       | Role    | Reference     |
+   +================+=========+===============+
+   | webdav         | send    | This document |
+   | webdav-receive | receive | This document |
+   | webapp         | send    | This document |
+   | webapp-receive | receive | This document |
+   | ssh            | send    | This document |
+   | ssh-receive    | receive | This document |
+   +================+=========+===============+
+~~~
+
+## OCM Share Types Registry
+
+IANA is requested to create the "OCM Share Types" registry in the
+"Open Cloud Mesh (OCM) Parameters" group.  Each entry records a share
+type that MAY appear in the "shareTypes" array advertised by the
+[OCM API Discovery](#ocm-api-discovery) endpoint or in the "shareType"
+field of a [Share Creation Notification](#share-creation-notification).
+
+   Registration Policy: Specification Required [RFC8126]
+
+   Initial Contents:
+
+~~~
+   +============+===============+
+   | Share Type | Reference     |
+   +============+===============+
+   | user       | This document |
+   | group      | This document |
+   | federation | This document |
+   +============+===============+
+~~~
+
+## OCM Share Payloads Registry
+
+IANA is requested to create the "OCM Share Payloads" registry in the
+"Open Cloud Mesh (OCM) Parameters" group.  Each entry records a
+combination of resource type, share type, and protocol for which a
+complete share payload is specified, together with a reference to the
+document that specifies that payload.
+
+The values in the "Resource Type", "Share Type", and "Protocol"
+columns MUST already appear in the "OCM Resource Types", "OCM Share
+Types", and "OCM Protocols" registries respectively.  For this
+registry, the Designated Expert MUST verify that the referenced
+specification completely specifies the share payload for the tuple,
+including every required and optional field and the full shape of the
+"protocol" details object.  A Sending Server MUST NOT send a share for
+a tuple that is not advertised by the Receiving Server in Discovery
+(see [Share Creation Notification](#share-creation-notification)).
+
+   Registration Policy: Specification Required [RFC8126]
+
+   Initial Contents:
+
+~~~
+   +===============+============+==========+===============+
+   | Resource Type | Share Type | Protocol | Reference     |
+   +===============+============+==========+===============+
+   | file          | user       | webdav   | This document |
+   | file          | user       | webapp   | This document |
+   | file          | user       | ssh      | This document |
+   | file          | group      | webdav   | This document |
+   | file          | group      | webapp   | This document |
+   | file          | group      | ssh      | This document |
+   | folder        | user       | webdav   | This document |
+   | folder        | user       | webapp   | This document |
+   | folder        | user       | ssh      | This document |
+   | folder        | group      | webdav   | This document |
+   | folder        | group      | webapp   | This document |
+   | folder        | group      | ssh      | This document |
+   +===============+============+==========+===============+
+~~~
+
+## OCM Notification Types Registry
+
+IANA is requested to create the "OCM Notification Types" registry in
+the "Open Cloud Mesh (OCM) Parameters" group.  This registry records
+the values that MAY appear in the "notificationType" field of an OCM
+notification sent to the "/notifications" endpoint (see
+[Share Acceptance Notification](#share-acceptance-notification)).
+
+The "Scope" field indicates whether the notification refers to a Share,
+in which case the "providerId" field is REQUIRED, or to a Group.  The
+"Status" field is one of "active" or "experimental".
+
+   Registration Policy: Specification Required [RFC8126]
+
+   Initial Contents:
+
+~~~
+   +===========================+=======+==============+===============+
+   | Notification Type         | Scope | Status       | Reference     |
+   +===========================+=======+==============+===============+
+   | SHARE_ACCEPTED            | Share | active       | This document |
+   | SHARE_DECLINED            | Share | active       | This document |
+   | SHARE_UNSHARED            | Share | active       | This document |
+   | REQUEST_RESHARE           | Share | experimental | This document |
+   | RESHARE_UNDO              | Share | experimental | This document |
+   | RESHARE_CHANGE_PERMISSION | Share | experimental | This document |
+   +===========================+=======+==============+===============+
+~~~
+
 # Security Considerations
 
 ## Trust
@@ -1613,6 +1792,10 @@ https://datatracker.ietf.org/doc/html/rfc7517)", May 2015.
 [RFC8032] Josefsson, S., Liusvaara, I., "[Edwards-Curve Digital
 Signature Algorithm (EdDSA)](
 https://datatracker.ietf.org/doc/html/rfc8032)", January 2017.
+
+[RFC8126] Cotton, M., Leiba, B. and Narten, T. "[Guidelines for
+Writing an IANA Considerations Section in RFCs](
+https://datatracker.ietf.org/doc/html/rfc8126)", June 2017.
 
 [RFC8174] Leiba, B. "[Ambiguity of Uppercase vs Lowercase in RFC 2119
 Key Words](https://datatracker.ietf.org/html/rfc8174)", May 2017.


### PR DESCRIPTION
This PR adds IANA registires for:

* notifications
* resourceTypes
* shareTypes
* protocols
* share payloads

It also registers OCM-MLS notification entries.

The idea with the registries is to try to find where the extension points of OCM should be. We want the protocol to be extensible AND interoperable. Where the spec is unclear or under-developed interoperability suffers. If we add extension points to the specification with out making it possible to explain how to use that extension point, only proprietary single vendor extensions are possible.

So for example writing in the specification text, that other kinds of notifications are allowed and that implementors MUST ignore notifications they don't understand, is adding an extension point, that is guaranteed not to be interoperable. The registries make sure that we get both extensibility AND interoperabilities at the same time.