### PR TITLE
Address reviewer feedback on httpsig

### DIFF
--- a/IETF-OCM.md
+++ b/IETF-OCM.md
@@ -771,12 +771,12 @@ contain the following information about its OCM API:
   `"/index.php/apps/sciencemesh/accept"` is specified here then a WAYF
   Page SHOULD redirect the end-user to `/index.php/apps/sciencemesh/
   accept?token=zi5kooKu3ivohr9a&providerDomain=cloud.example.org`.
-* OPTIONAL: jwksUri (string) - URL of a JWK Set document [RFC7517]
-  containing the public keys this OCM Server uses for HTTP Message
-  Signatures.  The URL is discovered from this field; it is not a
-  fixed path in the OCM API.
+* OPTIONAL: jwksUri (string) - https URL of a JWK Set document
+  [RFC7517] containing the public keys this OCM Server uses for HTTP
+  Message Signatures.  The URL is discovered from this field; it is
+  not a fixed path in the OCM API.
   Implementations that advertise the `"http-sig"` capability MUST
-  provide this URL as well.
+  provide this URL as well, and it MUST use https.
   Example: `"https://cloud.example.org/ocm/jwks"`.
 * OPTIONAL: tokenEndPoint (string) - URL of the token endpoint hosted by
   this OCM Server.  When this OCM Server acts as Sending Server, the
@@ -837,16 +837,17 @@ components:
 * "content-digest"      - [RFC9530] digest of the body
 * "content-length"      - message size
 
-The Signature-Input parameters MUST include `created` and `keyid`.
+The signature parameters MUST include `created` and `keyid`.
 Freshness and replay protection are anchored on `created` (see
 Verification Requirements).  The `keyid` value MUST be equal to the
 `kid` value of the corresponding key in the signer's JWK Set (see
 [Keys and Algorithms](#keys-and-algorithms)).
 
 The `Date` header is deliberately not covered by the signature:
-intermediaries commonly rewrite it, which would make signatures
-fragile, and the `created` signature parameter already conveys the
-message's creation time (see Section 7.2.4 of [RFC9421]).
+intermediaries sometimes rewrite it (see Section 6.6.1 of [RFC9110]),
+which would make signatures fragile, and the `created` signature
+parameter already conveys the message's creation time (see
+Section 7.2.4 of [RFC9421]).
 
 The `content-digest` component binds the request body to the signature,
 protecting it against modification in transit.  Its value MUST use a
@@ -1280,15 +1281,18 @@ A 503 response status means that the Receiver is temporary unavailable.
 The Receiving Server MAY discard the notification if any of the
 following hold true:
 
-* the HTTP Signature is missing but the Sending Server advertises the
-  `http-sig` capability in the Discovery response obtained from the
-  FQDN part of the `sender` field in the request body
-* the HTTP Signature is missing
-* the HTTP Signature is not valid (see [HTTP Message
+* the HTTP Message Signature is missing but the Sending Server
+  advertises the `http-sig` capability in the Discovery response
+  obtained from the FQDN part of the `sender` field in the request
+  body
+* the Sending Server advertises the `http-sig` capability but its
+  Discovery response carries no `jwksUri`
+* the HTTP Message Signature is missing
+* the HTTP Message Signature is not valid (see [HTTP Message
   Signatures](#http-message-signatures))
 * no trusted JWK Set can be obtained for the FQDN part of the
   `sender` field in the request body, via the `jwksUri` field of its
-  Discovery response or otherwise
+  Discovery response
 * that JWK Set contains no key whose `kid` equals the `keyid`
   signature parameter (see [HTTP Message
   Signatures](#http-message-signatures))
@@ -2064,6 +2068,10 @@ Key Words](https://datatracker.ietf.org/html/rfc8174)", May 2017.
 [RFC8615] Nottingham, M. "[Well-Known Uniform Resource Identifiers
 (URIs)](https://datatracker.ietf.org/doc/html/rfc8615)", May 2019
 
+[RFC9110] Fielding, R., Nottingham, M. and Reschke, J. "[HTTP
+Semantics](https://datatracker.ietf.org/doc/html/rfc9110)",
+June 2022.
+
 [RFC9421] Backman, A., Richer, J. and Sporny, M. "[HTTP Message
 Signatures](https://tools.ietf.org/html/rfc9421)", February 2024.
 
@@ -2075,7 +2083,8 @@ Representation of Contact Data](
 https://datatracker.ietf.org/doc/html/rfc9553), May 2024"
 
 [RFC9864] Jones, M., Steele, O., "[Fully-Specified Algorithms for
-JOSE and COSE](https://datatracker.ietf.org/doc/html/rfc9864)",
+JSON Object Signing and Encryption (JOSE) and CBOR Object Signing
+and Encryption (COSE)](https://datatracker.ietf.org/doc/html/rfc9864)",
 October 2025.
 
 ## Informative References
@@ -2122,7 +2131,7 @@ out of scope for this specification: a mechanism similar to the
 
 This appendix is informative.
 
-## JWKS Endpoint
+## Published JWK Set
 
 An OCM Server that advertises the `http-sig` capability publishes
 its public keys, in the format specified by [RFC7517], at the URL
@@ -2138,7 +2147,7 @@ an example response from `https://sender.example.org/ocm/jwks`:
       "crv": "Ed25519",
       "alg": "Ed25519",
       "kid": "sender.example.org#key1",
-      "x": "11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo"
+      "x": "AzeStPAdQ-vbi6bJVxcQjBPF2I7fDZdfDZ_XZ3J4Azs"
     }
   ]
 }
@@ -2184,10 +2193,10 @@ NOTE: '\' line wrapping per RFC 8792
 
 "@method": POST
 "@target-uri": https://receiver.example.org/ocm/shares
-"content-digest": sha-256=:[digest-value]:
-"content-length": [body-length]
+"content-digest": sha-256=:/Uz47cfD1HOdMTIqcWjd84iMLQ4gVJdC7ZFACf1ViqU=:
+"content-length": 521
 "@signature-params": ("@method" "@target-uri" "content-digest" \
-  "content-length");created=[timestamp];\
+  "content-length");created=1785060500;\
   keyid="sender.example.org#key1";alg="ed25519";tag="ocm"
 </sourcecode>
 
@@ -2200,12 +2209,13 @@ base above:
 <sourcecode type="http">
 NOTE: '\' line wrapping per RFC 8792
 
-Content-Digest: sha-256=:[digest-value]:
-Content-Length: [body-length]
+Content-Digest: sha-256=:/Uz47cfD1HOdMTIqcWjd84iMLQ4gVJdC7ZFACf1ViqU=:
+Content-Length: 521
 Signature-Input: sig1=("@method" "@target-uri" "content-digest" \
-  "content-length");created=[timestamp];\
+  "content-length");created=1785060500;\
   keyid="sender.example.org#key1";alg="ed25519";tag="ocm"
-Signature: sig1=:[signature-value]=:
+Signature: sig1=:Epax4XFqvbrrDzQUAaNl+uECasEKbArgz8AlEkXspvYX2fSkQFlC\
+  kaXImZnYU898C2t0IdmbFhjR8bkN0hZgCg==:
 </sourcecode>
 
 See [HTTP Message Signatures](#http-message-signatures) for the
@@ -2221,7 +2231,9 @@ illustrates the procedure to verify an incoming signed request:
    request body
 2. Fetch the Discovery response from
    `https://<provider-domain>/.well-known/ocm` and read its
-   `jwksUri` field
+   `jwksUri` field.  If the Sending Server advertises the `http-sig`
+   capability but no `jwksUri` is present, the receiver MUST reject
+   the request as non-conformant
 3. Fetch the public keys from the URL given by `jwksUri`
 4. Locate the unique signature carrying the `tag="ocm"` parameter in
    the `Signature-Input` header, disregarding its dictionary label
@@ -2238,7 +2250,7 @@ illustrates the procedure to verify an incoming signed request:
 ## Validating the Payload
 
 Following the validation of the signature, the host also confirms
-the validity of the payload, as required under Verification
+the validity of the payload, as specified under Verification
 Requirements in
 [HTTP Message Signatures](#http-message-signatures).
 

--- a/IETF-OCM.md
+++ b/IETF-OCM.md
@@ -1504,8 +1504,8 @@ for display purposes only):
 POST {tokenEndPoint} HTTP/1.1
 Host: cloud.example.org
 Content-Type: application/x-www-form-urlencoded
-Digest: SHA-256=ok6mQ3WZzKc8nb7s/Jt2yY1uK7d2n8Zq7dhl3Q0s1xk=
-Content-Length: 101
+Content-Digest: sha-256=:81kCnlO5UY/mZ8UgpxBWnq18GY3WhzJnDjOTvSvjbhw=:
+Content-Length: 80
 Signature-Input:
   sig1=("@method" "@target-uri" "content-digest");
   created=1730815200;

--- a/IETF-OCM.md
+++ b/IETF-OCM.md
@@ -834,9 +834,11 @@ components:
 * "content-digest"      - [RFC9530] digest of the body
 * "content-length"      - message size
 
-The Signature-Input parameters MUST include `created`.  Freshness and
-replay protection are anchored on `created` (see Verification
-Requirements).
+The Signature-Input parameters MUST include `created` and `keyid`.
+Freshness and replay protection are anchored on `created` (see
+Verification Requirements).  The `keyid` value MUST be equal to the
+`kid` value of the corresponding key in the signer's JWK Set (see
+[Keys and Algorithms](#keys-and-algorithms)).
 
 The `Date` header is deliberately not covered by the signature:
 intermediaries commonly rewrite it, which would make signatures
@@ -905,8 +907,9 @@ registry, the `alg` signature parameter MUST be omitted.
 ## Verification Requirements
 
 Verifiers MUST reject signatures that omit any of the mandatory
-components listed under Signing Requirements or the `created`
-parameter, and MUST reject signatures whose `created` value is more
+components listed under Signing Requirements or the `created` or
+`keyid` parameters, and MUST reject signatures whose `created` value
+is more
 than a small implementation-defined skew tolerance in the future, or
 older than the verifier's freshness window.
 
@@ -914,8 +917,9 @@ A `Content-Digest` header value carrying multiple algorithms MUST have
 every recognised digest match the body; a single match alongside a
 recognised mismatch MUST be treated as an integrity failure.
 
-Verifiers MUST reject a signature if the JWK identified by `keyid`
-does not carry an acceptable `alg` value (see
+Verifiers MUST reject a signature if the signer's JWK Set contains
+no key whose `kid` equals the `keyid` parameter, if the JWK
+identified by `keyid` does not carry an acceptable `alg` value (see
 [Keys and Algorithms](#keys-and-algorithms)), or if an `alg`
 signature parameter is present and does not correspond to the
 algorithm derived from that JWK.
@@ -2668,6 +2672,8 @@ process and it shall be removed when going to RFC last call.
 The complete changelog is updated in the OCM-API GitHub repository.
 
 ## Version 07
+* Required the `keyid` signature parameter and that it matches the
+  `kid` of the verification key in the signer's JWK Set.
 * The HTTP Message Signature algorithm is now derived from the JWK
   identified by `keyid`, per Section 3.3.7 of [RFC9421], instead of
   being restricted to the "HTTP Signature Algorithms" registry; the

--- a/IETF-OCM.md
+++ b/IETF-OCM.md
@@ -791,10 +791,11 @@ described in the respective sections.  This section specifies the
 normative requirements for producing and verifying those signatures.
 Appendix B contains a complete example.
 
-Public keys for signature verification are published as a JWK Set
-[RFC7517] at the URL advertised in the `jwksUri` field of the
-signer's [Discovery](#ocm-api-discovery) response, when the
-`http-sig` capability is advertised.
+Public keys for signature verification are distributed as follows:
+an OCM Server that advertises the `http-sig` capability MUST
+publish its public keys as a JWK Set [RFC7517] at the URL
+advertised in the `jwksUri` field of its
+[Discovery](#ocm-api-discovery) response.
 
 ## Applicability
 
@@ -935,6 +936,11 @@ discretion, or rejected when the receiver advertises
 `must-use-http-sig`).  Signatures without `tag="ocm"` MAY coexist (e.g.
 proxy-attached signatures) but verifiers MUST NOT process them as part
 of OCM signature processing.
+
+After successful signature verification, the verifier SHOULD confirm
+that the payload is consistent with the signer, i.e. that the
+actions implied by the payload were initiated on behalf of the
+origin of the request.
 
 ## Signing Direction Index
 
@@ -2109,11 +2115,14 @@ out of scope for this specification: a mechanism similar to the
 
 # Appendix B: JWKS and HTTP Signature Examples
 
+This appendix is informative.
+
 ## JWKS Endpoint
 
-An OCM Server that advertises the `http-sig` capability MUST publish
+An OCM Server that advertises the `http-sig` capability publishes
 its public keys, in the format specified by [RFC7517], at the URL
-advertised in the `jwksUri` field of its Discovery response.  Here is
+advertised in the `jwksUri` field of its Discovery response (see
+[HTTP Message Signatures](#http-message-signatures)).  Here is
 an example response from `https://sender.example.org/ocm/jwks`:
 
 ~~~
@@ -2196,10 +2205,8 @@ Signature-Input: sig1=("@method" "@target-uri" "content-digest"
 Signature: sig1=:[signature-value]=:
 </sourcecode>
 
-The covered components, the `created` parameter, the single `ocm`
-tag, and the prohibition on symmetric algorithms shown here are
-normative; see [HTTP Message Signatures](#http-message-signatures) for
-the full requirements.
+See [HTTP Message Signatures](#http-message-signatures) for the
+normative requirements illustrated by this example.
 
 ## Verifying a Signature (Receiver)
 
@@ -2225,10 +2232,10 @@ illustrates the procedure to verify an incoming signed request:
 
 ## Validating the Payload
 
-Following the validation of the signature, the host SHOULD also confirm
-the validity of the payload, that is ensuring that the actions implied
-in the payload actually initiated on behalf of the source of the
-request.
+Following the validation of the signature, the host also confirms
+the validity of the payload, as required under Verification
+Requirements in
+[HTTP Message Signatures](#http-message-signatures).
 
 As an example, if the payload is about initiating a new share, the file
 owner has to be an account from the instance at the origin of the

--- a/IETF-OCM.md
+++ b/IETF-OCM.md
@@ -1497,27 +1497,24 @@ To obtain an access token, the Receiving Server MUST send an HTTP POST
 request to the Sending Server’s {tokenEndPoint} as discovered in the
 OCM provider metadata, following section 4.4.2 of [RFC6749].  The
 request payload MUST be in `x-www-form-urlencoded` form, as shown
-in the following example (with line breaks in the Signature headers
-for display purposes only):
+in the following example:
 
 <sourcecode type="http">
+NOTE: '\' line wrapping per RFC 8792
+
 POST {tokenEndPoint} HTTP/1.1
 Host: cloud.example.org
 Content-Type: application/x-www-form-urlencoded
 Content-Digest: sha-256=:81kCnlO5UY/mZ8UgpxBWnq18GY3WhzJnDjOTvSvjbhw=:
 Content-Length: 80
-Signature-Input:
-  sig1=("@method" "@target-uri" "content-digest");
-  created=1730815200;
-  keyid="receiver.example.org#key1";
-  alg="ed25519";
-  tag="ocm"
-Signature: sig1=:bM2sV2a4oM8pWc4Q8r9Zb8bQ7a2vH1kR9xT0yJ3uE4wO5lV6bZ1cP
-  2rN3qD4tR5hC=:
+Signature-Input: sig1=("@method" "@target-uri" "content-digest");\
+  created=1730815200;keyid="receiver.example.org#key1";\
+  alg="ed25519";tag="ocm"
+Signature: sig1=:bM2sV2a4oM8pWc4Q8r9Zb8bQ7a2vH1kR9xT0yJ3uE4wO5lV6bZ\
+  1cP2rN3qD4tR5hC=:
 
-grant_type=authorization_code&
-client_id=receiver.example.org&
-code=my_secret_code
+grant_type=authorization_code&client_id=receiver.example.org&code=\
+  my_secret_code
 </sourcecode>
 
 The request MUST be signed using an HTTP Message Signature
@@ -2089,6 +2086,10 @@ in Open Cloud Mesh using Messaging Layer
 Security](https://datatracker.ietf.org/doc/draft-nordin-ocm-mls-federated-groups/)",
 Work in Progress, Internet-Draft.
 
+[RFC8792] Watsen, K., Auerswald, E., Farrel, A., Wu, Q., "[Handling
+Long Lines in Content of Internet-Drafts and RFCs](
+https://datatracker.ietf.org/doc/html/rfc8792)", June 2020.
+
 
 # Appendix A: Multi-factor Authentication
 
@@ -2171,37 +2172,34 @@ Content-Digest: sha-256=:LkpHyFOVbBDPxc7YbHDOWNzAv88qWuVfLNf4TUf9Uo8=:
 }
 </sourcecode>
 
-The signature base is constructed according to [RFC9421] (with line
-breaks in @signature-params for display purposes only):
+The signature base is constructed according to [RFC9421]:
 
 <sourcecode type="http">
+NOTE: '\' line wrapping per RFC 8792
+
 "@method": POST
 "@target-uri": https://receiver.example.org/ocm/shares
 "content-digest": sha-256=:[digest-value]:
 "content-length": [body-length]
-"@signature-params": ("@method" "@target-uri" "content-digest"
-    "content-length");
-    created=[timestamp];
-    keyid="sender.example.org#key1";
-    alg="ed25519";
-    tag="ocm"
+"@signature-params": ("@method" "@target-uri" "content-digest" \
+  "content-length");created=[timestamp];\
+  keyid="sender.example.org#key1";alg="ed25519";tag="ocm"
 </sourcecode>
 
 Sign this base using for example Ed25519 ([RFC8032]) to produce the
-signature, and then add headers (line breaks for display purposes
-only).  Note that the dictionary label (`sig1` below) is arbitrary; the
-signature is marked as belonging to OCM by its `tag="ocm"` parameter,
-which is part of the signature base above:
+signature, and then add headers.  Note that the dictionary label
+(`sig1` below) is arbitrary; the signature is marked as belonging
+to OCM by its `tag="ocm"` parameter, which is part of the signature
+base above:
 
 <sourcecode type="http">
+NOTE: '\' line wrapping per RFC 8792
+
 Content-Digest: sha-256=:[digest-value]:
 Content-Length: [body-length]
-Signature-Input: sig1=("@method" "@target-uri" "content-digest"
-    "content-length");
-  created=[timestamp];
-  keyid="sender.example.org#key1";
-  alg="ed25519";
-  tag="ocm"
+Signature-Input: sig1=("@method" "@target-uri" "content-digest" \
+  "content-length");created=[timestamp];\
+  keyid="sender.example.org#key1";alg="ed25519";tag="ocm"
 Signature: sig1=:[signature-value]=:
 </sourcecode>
 

--- a/IETF-OCM.md
+++ b/IETF-OCM.md
@@ -776,7 +776,9 @@ contain the following information about its OCM API:
   Message Signatures.  The URL is discovered from this field; it is
   not a fixed path in the OCM API.
   Implementations that advertise the `"http-sig"` capability MUST
-  provide this URL as well, and it MUST use https.
+  provide this URL as well, and it MUST use https.  As with the
+  Discovery Process, implementations MAY fallback to HTTP instead of
+  HTTPS in testing setups.
   Example: `"https://cloud.example.org/ocm/jwks"`.
 * OPTIONAL: tokenEndPoint (string) - URL of the token endpoint hosted by
   this OCM Server.  When this OCM Server acts as Sending Server, the
@@ -838,8 +840,10 @@ components:
 * "content-length"      - message size
 
 The signature parameters MUST include `created` and `keyid`.
-Freshness and replay protection are anchored on `created` (see
-Verification Requirements).  The `keyid` value MUST be equal to the
+Freshness is anchored on `created` (see Verification Requirements);
+`created` bounds how long a captured signature stays acceptable, but
+does not by itself detect replay within that window (see Section
+7.2.2 of [RFC9421]).  The `keyid` value MUST be equal to the
 `kid` value of the corresponding key in the signer's JWK Set (see
 [Keys and Algorithms](#keys-and-algorithms)).
 
@@ -2000,7 +2004,9 @@ Implementers SHOULD NOT use it and prefer short-lived tokens instead.
 ##  Code Flow
 
 All `{tokenEndPoint}` requests MUST be transmitted over HTTPS and
-signed using HTTP Signatures.  Bearer tokens MUST be treated as
+signed using HTTP Signatures.  As with the Discovery Process,
+implementations MAY fallback to HTTP instead of HTTPS in testing
+setups.  Bearer tokens MUST be treated as
 confidential and never logged, persisted beyond their lifetime, or
 transmitted over unsecured channels.
 
@@ -2232,8 +2238,9 @@ illustrates the procedure to verify an incoming signed request:
 2. Fetch the Discovery response from
    `https://<provider-domain>/.well-known/ocm` and read its
    `jwksUri` field.  If the Sending Server advertises the `http-sig`
-   capability but no `jwksUri` is present, the receiver MUST reject
-   the request as non-conformant
+   capability but no `jwksUri` is present, the receiver can discard
+   the notification, as described in [Decision to
+   Discard](#decision-to-discard)
 3. Fetch the public keys from the URL given by `jwksUri`
 4. Locate the unique signature carrying the `tag="ocm"` parameter in
    the `Signature-Input` header, disregarding its dictionary label
@@ -2708,6 +2715,16 @@ The complete changelog is updated in the OCM-API GitHub repository.
 * The `Date` header is no longer covered by signatures: freshness is
   anchored on the `created` signature parameter (see Section 7.2.4
   of [RFC9421]).
+* Clarified that `created` bounds the lifetime of a captured
+  signature but does not by itself detect replay within that window
+  (see Section 7.2.2 of [RFC9421]).
+* `jwksUri` and `{tokenEndPoint}` transport: https remains mandatory,
+  with the same HTTP fallback allowance for testing setups that the
+  Discovery Process has; dropped the https-only schema pattern from
+  spec.yaml accordingly.
+* Appendix B now defers the missing-`jwksUri` case to [Decision to
+  Discard](#decision-to-discard) instead of stating a stronger
+  requirement in an informative section.
 * Updated the signature examples: replaced the legacy `Digest` header
   with `Content-Digest` [RFC9530] and applied [RFC8792] line
   wrapping.

--- a/IETF-OCM.md
+++ b/IETF-OCM.md
@@ -2784,8 +2784,8 @@ Peter Szegedi, Ron Trompert, Benedikt Wegmann and Jonathan Xu.
 We would also like to thank Ishank Arora, Gianmaria Del Monte,
 Jörn Friedrich Dreyer, Richard Freitag, Hugo González Labrador,
 Matthias Kraus, Maxence Lange, Lovisa Lugnegård, Thibault Meunier,
-Sandro Mesterheide, Antoon Prins and Björn Schießle for their direct
-contributions to the specification.
+Sandro Mesterheide, Antoon Prins, Justin Richer and Björn Schießle for
+their direct contributions to the specification.
 
 Over the years many more people have been involved in the development
 of OCM.  We would like to thank all of them for their contributions,

--- a/IETF-OCM.md
+++ b/IETF-OCM.md
@@ -858,11 +858,49 @@ A request MUST include one and only one signature carrying
 `tag="ocm"`.  The signature label MAY be any value; it is not
 significant to OCM processing.
 
-The signature MUST use an asymmetric algorithm from the IANA "HTTP
-Signature Algorithms" registry [IANA-SIG-ALG]; `ed25519` [RFC8032] is
-RECOMMENDED.  A symmetric algorithm, such as the HMAC-based
-`hmac-sha256`, MUST NOT be used, as the Receiving Server would not be
-able to verify the signature without prior access to the shared secret.
+The signature algorithm is determined by the signing key material;
+see [Keys and Algorithms](#keys-and-algorithms).
+
+## Keys and Algorithms
+
+Each key published in the signer's JWK Set MUST include the `kid`
+and `alg` parameters [RFC7517].  The JWK `alg` value MUST identify
+an asymmetric signature algorithm registered in the IANA "JSON Web
+Signature and Encryption Algorithms" registry [RFC7518], and SHOULD
+be a fully-specified algorithm [RFC9864]; `Ed25519` ([RFC8032],
+[RFC9864]) is RECOMMENDED.
+
+The signature algorithm is derived from the key material rather
+than declared by the message: signers and verifiers MUST determine
+the algorithm from the `alg` parameter of the JWK identified by the
+`keyid` signature parameter, and apply it to the signature base as
+specified in Section 3.3.7 of [RFC9421].
+
+This way, implementations are neither restricted to the algorithms
+listed in the IANA "HTTP Signature Algorithms" registry
+(Section 6.2 of [RFC9421]), nor is an update to this document
+needed as new algorithms, for example post-quantum ones, are
+registered for JOSE: as noted in that section, an application is
+free to use any algorithm provided the signer and verifier can
+agree on it in a secure and deterministic fashion, and the JWK
+`alg` parameter provides that agreement.
+
+The JWS algorithm `none` and symmetric MAC algorithms, such as
+`HS256`, MUST NOT be used: the former provides no protection, while
+the latter would require the verifier to have prior access to a
+shared secret.
+
+The `alg` signature parameter is OPTIONAL: the algorithm is always
+determined by the JWK, as described above.  Note that this
+parameter takes its values from a different registry than the JWK
+`alg` value.  If the parameter is present, the algorithm it names
+in the IANA "HTTP Signature Algorithms" registry [IANA-SIG-ALG]
+MUST denote the same algorithm as the JWK `alg` value, for
+example, `ed25519` for a JWK with `alg` `Ed25519`, and verifiers
+MUST reject the signature otherwise
+(see Section 7 of [RFC9421] on algorithm confusion and substitution
+attacks).  When the JWK algorithm has no counterpart in that
+registry, the `alg` signature parameter MUST be omitted.
 
 ## Verification Requirements
 
@@ -875,6 +913,12 @@ older than the verifier's freshness window.
 A `Content-Digest` header value carrying multiple algorithms MUST have
 every recognised digest match the body; a single match alongside a
 recognised mismatch MUST be treated as an integrity failure.
+
+Verifiers MUST reject a signature if the JWK identified by `keyid`
+does not carry an acceptable `alg` value (see
+[Keys and Algorithms](#keys-and-algorithms)), or if an `alg`
+signature parameter is present and does not correspond to the
+algorithm derived from that JWK.
 
 Verifiers MUST identify the OCM signature by its `tag="ocm"`
 parameter, examining the parameters of each member of the
@@ -1992,6 +2036,9 @@ Specifications and Registration Procedures
 [RFC7517] Jones, M., "[JSON Web Key (JWK)](
 https://datatracker.ietf.org/doc/html/rfc7517)", May 2015.
 
+[RFC7518] Jones, M., "[JSON Web Algorithms (JWA)](
+https://datatracker.ietf.org/doc/html/rfc7518)", May 2015.
+
 [RFC8032] Josefsson, S., Liusvaara, I., "[Edwards-Curve Digital
 Signature Algorithm (EdDSA)](
 https://datatracker.ietf.org/doc/html/rfc8032)", January 2017.
@@ -2015,6 +2062,10 @@ https://datatracker.ietf.org/doc/html/rfc9530)", February 2024.
 [RFC9553] Stepanek, R., Loffredo, M., "[JSContact: A JSON
 Representation of Contact Data](
 https://datatracker.ietf.org/doc/html/rfc9553), May 2024"
+
+[RFC9864] Jones, M., Steele, O., "[Fully-Specified Algorithms for
+JOSE and COSE](https://datatracker.ietf.org/doc/html/rfc9864)",
+October 2025.
 
 ## Informative References
 
@@ -2067,6 +2118,7 @@ an example response from `https://sender.example.org/ocm/jwks`:
     {
       "kty": "OKP",
       "crv": "Ed25519",
+      "alg": "Ed25519",
       "kid": "sender.example.org#key1",
       "x": "11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo"
     }
@@ -2616,6 +2668,10 @@ process and it shall be removed when going to RFC last call.
 The complete changelog is updated in the OCM-API GitHub repository.
 
 ## Version 07
+* The HTTP Message Signature algorithm is now derived from the JWK
+  identified by `keyid`, per Section 3.3.7 of [RFC9421], instead of
+  being restricted to the "HTTP Signature Algorithms" registry; the
+  `alg` signature parameter is optional and checked for consistency.
 * Replaced the unregistered `/.well-known/jwks.json` endpoint with a
   `jwksUri` field in the Discovery response, from which the location
   of the JWK Set for HTTP Message Signatures is discovered.

--- a/IETF-OCM.md
+++ b/IETF-OCM.md
@@ -831,8 +831,10 @@ The Signature-Input parameters MUST include `created`.  Freshness and
 replay protection are anchored on `created` (see Verification
 Requirements).
 
-A signed request SHOULD additionally cover the `date` component when a
-`Date` header is present.
+The `Date` header is deliberately not covered by the signature:
+intermediaries commonly rewrite it, which would make signatures
+fragile, and the `created` signature parameter already conveys the
+message's creation time (see Section 7.2.4 of [RFC9421]).
 
 The `content-digest` component binds the request body to the signature,
 protecting it against modification in transit.  Its value MUST use a
@@ -1440,12 +1442,11 @@ for display purposes only):
 <sourcecode type="http">
 POST {tokenEndPoint} HTTP/1.1
 Host: cloud.example.org
-Date: Wed, 05 Nov 2025 14:00:00 GMT
 Content-Type: application/x-www-form-urlencoded
 Digest: SHA-256=ok6mQ3WZzKc8nb7s/Jt2yY1uK7d2n8Zq7dhl3Q0s1xk=
 Content-Length: 101
 Signature-Input:
-  sig1=("@method" "@target-uri" "content-digest" "date");
+  sig1=("@method" "@target-uri" "content-digest");
   created=1730815200;
   keyid="receiver.example.org#key1";
   alg="ed25519";
@@ -2074,7 +2075,6 @@ Given a Share Creation Notification request:
 <sourcecode type="http">
 POST /ocm/shares HTTP/1.1
 Host: receiver.example.org
-Date: Fri, 16 Jan 2026 13:37:00 GMT
 Content-Type: application/json
 Content-Digest: sha-256=:LkpHyFOVbBDPxc7YbHDOWNzAv88qWuVfLNf4TUf9Uo8=:
 
@@ -2107,9 +2107,8 @@ breaks in @signature-params for display purposes only):
 "@target-uri": https://receiver.example.org/ocm/shares
 "content-digest": sha-256=:[digest-value]:
 "content-length": [body-length]
-"date": [date]
 "@signature-params": ("@method" "@target-uri" "content-digest"
-    "content-length" "date");
+    "content-length");
     created=[timestamp];
     keyid="sender.example.org#key1";
     alg="ed25519";
@@ -2125,9 +2124,8 @@ which is part of the signature base above:
 <sourcecode type="http">
 Content-Digest: sha-256=:[digest-value]:
 Content-Length: [body-length]
-Date: [date]
 Signature-Input: sig1=("@method" "@target-uri" "content-digest"
-    "content-length" "date");
+    "content-length");
   created=[timestamp];
   keyid="sender.example.org#key1";
   alg="ed25519";

--- a/IETF-OCM.md
+++ b/IETF-OCM.md
@@ -719,9 +719,9 @@ contain the following information about its OCM API:
   acts as Receiving Server, it can honor inbound shares that require
   token exchange.
   - `"http-sig"` - to indicate that this OCM Server supports
-  [RFC9421] HTTP Message Signatures and advertises public keys in the
-  format specified by [RFC7517] at the `/.well-known/jwks.json`
-  endpoint for signature verification.
+  [RFC9421] HTTP Message Signatures and advertises the public keys
+  for signature verification, in the format specified by [RFC7517],
+  at the URL given by the `jwksUri` field.
   - `"invites"` - to indicate the server would support acting as an
   Invite Sender or Invite Receiver OCM Server.  This might be useful
   for suggesting to a user that existing contacts might be upgraded
@@ -769,6 +769,13 @@ contain the following information about its OCM API:
   `"/index.php/apps/sciencemesh/accept"` is specified here then a WAYF
   Page SHOULD redirect the end-user to `/index.php/apps/sciencemesh/
   accept?token=zi5kooKu3ivohr9a&providerDomain=cloud.example.org`.
+* OPTIONAL: jwksUri (string) - URL of a JWK Set document [RFC7517]
+  containing the public keys this OCM Server uses for HTTP Message
+  Signatures.  The URL is discovered from this field; it is not a
+  fixed path in the OCM API.
+  Implementations that advertise the `"http-sig"` capability MUST
+  provide this URL as well.
+  Example: `"https://cloud.example.org/ocm/jwks"`.
 * OPTIONAL: tokenEndPoint (string) - URL of the token endpoint hosted by
   this OCM Server.  When this OCM Server acts as Sending Server, the
   Receiving Server POSTs here to exchange a `sharedSecret` for a
@@ -784,10 +791,10 @@ described in the respective sections.  This section specifies the
 normative requirements for producing and verifying those signatures.
 Appendix B contains a complete example.
 
-Public keys for signature verification are published in the format
-specified by [RFC7517] at the signer's `/.well-known/jwks.json`
-endpoint, if the `http-sig` capability is included in the
-[Discovery](#ocm-api-discovery) response.
+Public keys for signature verification are published as a JWK Set
+[RFC7517] at the URL advertised in the `jwksUri` field of the
+signer's [Discovery](#ocm-api-discovery) response, when the
+`http-sig` capability is advertised.
 
 ## Applicability
 
@@ -2049,10 +2056,10 @@ out of scope for this specification: a mechanism similar to the
 
 ## JWKS Endpoint
 
-An OCM Server that advertises the `http-sig` capability MUST expose its
-public keys at `/.well-known/jwks.json` in the format specified by
-[RFC7517].  Here is an example response from
-`https://sender.example.org/.well-known/jwks.json`:
+An OCM Server that advertises the `http-sig` capability MUST publish
+its public keys, in the format specified by [RFC7517], at the URL
+advertised in the `jwksUri` field of its Discovery response.  Here is
+an example response from `https://sender.example.org/ocm/jwks`:
 
 ~~~
 {
@@ -2146,16 +2153,18 @@ illustrates the procedure to verify an incoming signed request:
 
 1. Extract the provider domain from the `sender` field in the
    request body
-2. Fetch the public key from
-   `https://<provider-domain>/.well-known/jwks.json`
-3. Locate the unique signature carrying the `tag="ocm"` parameter in
+2. Fetch the Discovery response from
+   `https://<provider-domain>/.well-known/ocm` and read its
+   `jwksUri` field
+3. Fetch the public keys from the URL given by `jwksUri`
+4. Locate the unique signature carrying the `tag="ocm"` parameter in
    the `Signature-Input` header, disregarding its dictionary label
    (here `sig1`)
-4. Extract `keyid` from `Signature-Input` header and find the key
+5. Extract `keyid` from `Signature-Input` header and find the key
    matching the `kid` value in the [RFC7517] response
-5. Reconstruct the signature base from the request using the
+6. Reconstruct the signature base from the request using the
    components listed in `Signature-Input` as specified in [RFC9421]
-6. Verify the signature using the appropriate algorithm
+7. Verify the signature using the appropriate algorithm
    (e.g., Ed25519 [RFC8032])
 
 ## Validating the Payload
@@ -2607,6 +2616,9 @@ process and it shall be removed when going to RFC last call.
 The complete changelog is updated in the OCM-API GitHub repository.
 
 ## Version 07
+* Replaced the unregistered `/.well-known/jwks.json` endpoint with a
+  `jwksUri` field in the Discovery response, from which the location
+  of the JWK Set for HTTP Message Signatures is discovered.
 * Added informative aids: same-string note for `must-exchange-token`,
   Appendix D criteria label fix, [Signing Direction
   Index](#signing-direction-index), [Appendix E: Navigation

--- a/IETF-OCM.md
+++ b/IETF-OCM.md
@@ -215,7 +215,8 @@ related concepts from OAuth [RFC6749] and elsewhere:
   membership or prior interactions, SHOULD be recorded in an internal
   registry of trusted servers, that SHOULD be updated over time based
   on new information.  The registry SHOULD include the FQDN of the
-  trusted server and the Public Key used for HTTP Signatures.  It MAY
+  trusted server and the public keys (JWK Set [RFC7517]) used for
+  HTTP Message Signatures.  It MAY
   also include additional metadata such as the inviteAcceptDialog URL
   or supported capabilities.
 * __WAYF Page__ - A Where-Are-You-From page is a discovery service used
@@ -578,8 +579,9 @@ The next step is for the Sending Server to additionally discover:
 * if the Receiving Server supports OCM
 * if so, which version and with which optional functionality
 * at which URL
-* the public key the Receiving Server will use for HTTP Signatures (if
-  any)
+* the public keys the Receiving Server will use for HTTP Message
+  Signatures (if any), published as a JWK Set at the URL given by the
+  `jwksUri` field
 
 The Sending Server MAY first perform denylist and allowlist checks on
 the FQDN.
@@ -1278,16 +1280,18 @@ A 503 response status means that the Receiver is temporary unavailable.
 The Receiving Server MAY discard the notification if any of the
 following hold true:
 
-* the HTTP Signature is missing but the Sending Server does expose a
-  keypair discoverable from the FQDN part of the `sender` field in the
-  request body
+* the HTTP Signature is missing but the Sending Server advertises the
+  `http-sig` capability in the Discovery response obtained from the
+  FQDN part of the `sender` field in the request body
 * the HTTP Signature is missing
-* the HTTP Signature is not valid
-* no keypair is trusted or discoverable from the FQDN part of the
-  `sender` field in the request body
-* the keypair used to generate the HTTP Signature doesn't match the one
-  trusted or discoverable from the FQDN part of the `sender` field
-  in the request body
+* the HTTP Signature is not valid (see [HTTP Message
+  Signatures](#http-message-signatures))
+* no trusted JWK Set can be obtained for the FQDN part of the
+  `sender` field in the request body, via the `jwksUri` field of its
+  Discovery response or otherwise
+* that JWK Set contains no key whose `kid` equals the `keyid`
+  signature parameter (see [HTTP Message
+  Signatures](#http-message-signatures))
 * the Sending Server is denylisted
 * the Sending Server is not allowlisted
 * the Sending Party is not trusted by the Receiving Party (e.g., no
@@ -1507,9 +1511,9 @@ Host: cloud.example.org
 Content-Type: application/x-www-form-urlencoded
 Content-Digest: sha-256=:81kCnlO5UY/mZ8UgpxBWnq18GY3WhzJnDjOTvSvjbhw=:
 Content-Length: 80
-Signature-Input: sig1=("@method" "@target-uri" "content-digest");\
-  created=1730815200;keyid="receiver.example.org#key1";\
-  alg="ed25519";tag="ocm"
+Signature-Input: sig1=("@method" "@target-uri" "content-digest" \
+  "content-length");created=1730815200;\
+  keyid="receiver.example.org#key1";alg="ed25519";tag="ocm"
 Signature: sig1=:bM2sV2a4oM8pWc4Q8r9Zb8bQ7a2vH1kR9xT0yJ3uE4wO5lV6bZ\
   1cP2rN3qD4tR5hC=:
 
@@ -2149,7 +2153,8 @@ Given a Share Creation Notification request:
 POST /ocm/shares HTTP/1.1
 Host: receiver.example.org
 Content-Type: application/json
-Content-Digest: sha-256=:LkpHyFOVbBDPxc7YbHDOWNzAv88qWuVfLNf4TUf9Uo8=:
+Content-Digest: sha-256=:/Uz47cfD1HOdMTIqcWjd84iMLQ4gVJdC7ZFACf1ViqU=:
+Content-Length: 521
 
 {
   "shareWith": "marie@receiver.example.org",
@@ -2225,8 +2230,10 @@ illustrates the procedure to verify an incoming signed request:
    matching the `kid` value in the [RFC7517] response
 6. Reconstruct the signature base from the request using the
    components listed in `Signature-Input` as specified in [RFC9421]
-7. Verify the signature using the appropriate algorithm
-   (e.g., Ed25519 [RFC8032])
+7. Verify the signature using the algorithm derived from the `alg`
+   value of that JWK (e.g., Ed25519 [RFC8032]), as described under
+   Keys and Algorithms in
+   [HTTP Message Signatures](#http-message-signatures)
 
 ## Validating the Payload
 
@@ -2686,6 +2693,12 @@ The complete changelog is updated in the OCM-API GitHub repository.
 * Replaced the unregistered `/.well-known/jwks.json` endpoint with a
   `jwksUri` field in the Discovery response, from which the location
   of the JWK Set for HTTP Message Signatures is discovered.
+* The `Date` header is no longer covered by signatures: freshness is
+  anchored on the `created` signature parameter (see Section 7.2.4
+  of [RFC9421]).
+* Updated the signature examples: replaced the legacy `Digest` header
+  with `Content-Digest` [RFC9530] and applied [RFC8792] line
+  wrapping.
 * Added informative aids: same-string note for `must-exchange-token`,
   Appendix D criteria label fix, [Signing Direction
   Index](#signing-direction-index), [Appendix E: Navigation

--- a/spec.yaml
+++ b/spec.yaml
@@ -534,14 +534,14 @@ components:
         jwksUri:
           type: string
           format: uri
-          pattern: "^https://"
           description: >
             Optional URL of a JWK Set document [RFC7517] containing the
             public keys this OCM Server uses for HTTP Message Signatures
             [RFC9421]. The URL is discovered from this field; it is not a
             fixed path in the OCM API. If the `http-sig` capability is
             exposed, the jwksUri MUST be advertised in the discovery
-            response and MUST use https.
+            response and MUST use https, though implementations MAY fall
+            back to HTTP in testing setups.
           example: https://cloud.example.org/ocm/jwks
         tokenEndPoint:
           type: string

--- a/spec.yaml
+++ b/spec.yaml
@@ -534,13 +534,14 @@ components:
         jwksUri:
           type: string
           format: uri
+          pattern: "^https://"
           description: >
             Optional URL of a JWK Set document [RFC7517] containing the
             public keys this OCM Server uses for HTTP Message Signatures
             [RFC9421]. The URL is discovered from this field; it is not a
             fixed path in the OCM API. If the `http-sig` capability is
             exposed, the jwksUri MUST be advertised in the discovery
-            response.
+            response and MUST use https.
           example: https://cloud.example.org/ocm/jwks
         tokenEndPoint:
           type: string

--- a/spec.yaml
+++ b/spec.yaml
@@ -531,6 +531,17 @@ components:
           example:
             - allowlist
             - must-invite
+        jwksUri:
+          type: string
+          format: uri
+          description: >
+            Optional URL of a JWK Set document [RFC7517] containing the
+            public keys this OCM Server uses for HTTP Message Signatures
+            [RFC9421]. The URL is discovered from this field; it is not a
+            fixed path in the OCM API. If the `http-sig` capability is
+            exposed, the jwksUri MUST be advertised in the discovery
+            response.
+          example: https://cloud.example.org/ocm/jwks
         tokenEndPoint:
           type: string
           format: uri
@@ -916,7 +927,7 @@ components:
             multipleProtocols:
               name: multi
               webdav:
-                accessTypes: ['remote', 'datatx']
+                accessTypes: ["remote", "datatx"]
                 uri: https://cloud.example.org/remote/dav/ocm/7c084226-d9a1-11e6-bf26-cec0c932ce01
                 sharedSecret: hfiuhworzwnur98d3wjiwhr
                 permissions:
@@ -940,7 +951,7 @@ components:
                   - text/markdown
                   - text/html
               ssh:
-                accessTypes: ['datatx']
+                accessTypes: ["datatx"]
                 uri: extuser@cloud.example.org:/7c084226-d9a1-11e6-bf26-cec0c932ce01
     NewNotification:
       type: object


### PR DESCRIPTION
## Address HTTPSig review feedback

This PR addresses the review feedback from Justin Richer on the
HTTP Message Signatures section of the draft.

### Changes

**Date header** 

The `Date` header is no longer covered by signatures: intermediaries commonly rewrite it, and the `created` signature parameter already conveys creation time (RFC 9421 §7.2.4).

**Algorithm derivation**

The signature algorithm is now derived from the key material instead of being restricted to the IANA "HTTP Signature Algorithms" registry. Each JWK MUST carry `kid` and `alg`; the JWK `alg` MUST be an asymmetric JOSE-registered algorithm and SHOULD be fully-specified per RFC 9864 (`Ed25519` RECOMMENDED, which also replaces the RFC 8037 reference). The algorithm is applied per RFC 9421 §3.3.7, so new (e.g. post-quantum) JOSE algorithms work without updating this document. `none` and MACs are forbidden. The HTTPSig `alg` signature parameter is OPTIONAL; if present it MUST denote the same algorithm as the JWK, and is omitted when no registry  counterpart exists. A new "Keys and Algorithms" subsection holds this text.

**JWKS discovery**

The unregistered `/.well-known/jwks.json` endpoint is replaced by a `jwksUri` field in the Discovery response (also added to `spec.yaml`). Servers advertising the `http-sig` capability MUST provide it.

**keyid**

The `keyid` signature parameter is now REQUIRED and MUST equal the `kid` of the verification key in the signer's JWK Set; verifiers reject signatures with no matching key.

**Informative examples**

Appendix B is now explicitly informative; its normative statements were moved into the HTTP Message Signatures section. All signature examples use RFC 8792 line wrapping, and the
Token Request example uses `Content-Digest` (RFC 9530) instead of the legacy `Digest` header, with real digest values.

**Consistency pass** 

The Trusted Server definition, Discovery introduction, and Decision to Discard now speak of JWK Sets discovered via `jwksUri` and the `keyid`/`kid` match; the Token Request example covers `content-length` as required; the Appendix B example carries a real `Content-Digest` and `Content-Length`.

The Version 07 changelog records all of the above.