### PR TITLE
Notifications rehaul

### DIFF
--- a/IETF-OCM-MLS.md
+++ b/IETF-OCM-MLS.md
@@ -736,7 +736,7 @@ added user.
 {
   "notificationType": "MLS_WELCOME",
   "senderDomain": "othercloud.example.org",
-  "resourceType": "federation",
+  "shareType": "federation",
   "notification": {
     "federation": {
       "mlsGroupId": "<base64url MLS group ID>",
@@ -780,7 +780,7 @@ act on it.
 {
   "notificationType": "MLS_PROPOSAL",
   "senderDomain": "cloud.example.org",
-  "resourceType": "federation",
+  "shareType": "federation",
   "notification": {
     "federation": {
       "mlsGroupId": "<base64url MLS group ID>",
@@ -812,7 +812,7 @@ data, per [RFC9420] Section 15.2.
 {
   "notificationType": "MLS_COMMIT",
   "senderDomain": "cloud.example.org",
-  "resourceType": "federation",
+  "shareType": "federation",
   "notification": {
     "federation": {
       "mlsGroupId": "<base64url MLS group ID>",
@@ -864,7 +864,7 @@ epoch ([RFC9420] Section 15).
 {
   "notificationType": "MLS_APPLICATION",
   "senderDomain": "cloud.example.org",
-  "resourceType": "federation",
+  "shareType": "federation",
   "notification": {
     "federation": {
       "mlsGroupId": "<base64url MLS group ID>",
@@ -909,7 +909,7 @@ by the KeyPackage endpoint.
 {
   "notificationType": "MLS_REJOIN",
   "senderDomain": "othercloud.example.org",
-  "resourceType": "federation",
+  "shareType": "federation",
   "notification": {
     "federation": {
       "mlsGroupId": "<base64url MLS group ID>",
@@ -1574,8 +1574,8 @@ Each notification MAY include the optional `encryption` field:
 ~~~ json
 {
   "shareWith": "research-group@receiver.example.org",
-  "shareType": "federation",
   "resourceType": "file",
+  "shareType": "federation",
   "sender": "alice@cloud.example.org",
   "owner": "alice@cloud.example.org",
   "providerId": "7c084226-d9a1-11e6-bf26-cec0c932ce01",

--- a/IETF-OCM-MLS.md
+++ b/IETF-OCM-MLS.md
@@ -735,10 +735,14 @@ added user.
 ~~~ json
 {
   "notificationType": "MLS_WELCOME",
+  "senderDomain": "othercloud.example.org",
+  "resourceType": "federation",
   "notification": {
-    "mlsGroupId": "<base64url MLS group ID>",
-    "userId": "bob@othercloud.example.org",
-    "content": "<base64url MLS Welcome wire format>"
+    "federation": {
+      "mlsGroupId": "<base64url MLS group ID>",
+      "userId": "bob@othercloud.example.org",
+      "content": "<base64url MLS Welcome wire format>"
+    }
   }
 }
 ~~~
@@ -775,9 +779,13 @@ act on it.
 ~~~ json
 {
   "notificationType": "MLS_PROPOSAL",
+  "senderDomain": "cloud.example.org",
+  "resourceType": "federation",
   "notification": {
-    "mlsGroupId": "<base64url MLS group ID>",
-    "content": "<base64url MLS PublicMessage carrying the Proposal>"
+    "federation": {
+      "mlsGroupId": "<base64url MLS group ID>",
+      "content": "<base64url MLS PublicMessage carrying the Proposal>"
+    }
   }
 }
 ~~~
@@ -803,10 +811,16 @@ data, per [RFC9420] Section 15.2.
 ~~~ json
 {
   "notificationType": "MLS_COMMIT",
+  "senderDomain": "cloud.example.org",
+  "resourceType": "federation",
   "notification": {
-    "mlsGroupId": "<base64url MLS group ID>",
-    "proposals": ["<base64url MLS PublicMessage carrying a Proposal>"],
-    "content": "<base64url MLS PublicMessage carrying the Commit>"
+    "federation": {
+      "mlsGroupId": "<base64url MLS group ID>",
+      "proposals": [
+        "<base64url MLS PublicMessage carrying a Proposal>"
+      ],
+      "content": "<base64url MLS PublicMessage carrying the Commit>"
+    }
   }
 }
 ~~~
@@ -849,9 +863,13 @@ epoch ([RFC9420] Section 15).
 ~~~ json
 {
   "notificationType": "MLS_APPLICATION",
+  "senderDomain": "cloud.example.org",
+  "resourceType": "federation",
   "notification": {
-    "mlsGroupId": "<base64url MLS group ID>",
-    "content": "<base64url MLS PrivateMessage wire format>"
+    "federation": {
+      "mlsGroupId": "<base64url MLS group ID>",
+      "content": "<base64url MLS PrivateMessage wire format>"
+    }
   }
 }
 ~~~
@@ -890,16 +908,20 @@ by the KeyPackage endpoint.
 ~~~ json
 {
   "notificationType": "MLS_REJOIN",
+  "senderDomain": "othercloud.example.org",
+  "resourceType": "federation",
   "notification": {
-    "mlsGroupId": "<base64url MLS group ID>",
-    "keyPackages": [
-      {
-        "userId": "bob@othercloud.example.org",
-        "mediaType": "message/mls",
-        "encoding": "base64url",
-        "content": "<base64url-encoded MLS KeyPackage>"
-      }
-    ]
+    "federation": {
+      "mlsGroupId": "<base64url MLS group ID>",
+      "keyPackages": [
+        {
+          "userId": "bob@othercloud.example.org",
+          "mediaType": "message/mls",
+          "encoding": "base64url",
+          "content": "<base64url-encoded MLS KeyPackage>"
+        }
+      ]
+    }
   }
 }
 ~~~
@@ -1880,19 +1902,18 @@ defined in [RFC9420] Section 17.3:
 
 The following notification types are to be registered in the "OCM
 Notification Types" registry defined in [OCM], within the "Open Cloud
-Mesh (OCM) Parameters" group.  All are group-scoped and therefore omit
-the "providerId" field (see {{mls-notification-types}}):
+Mesh (OCM) Parameters" group:
 
 ~~~
-   +===================+=======+========+===============+
-   | Notification Type | Scope | Status | Reference     |
-   +===================+=======+========+===============+
-   | MLS_WELCOME       | Group | active | This document |
-   | MLS_PROPOSAL      | Group | active | This document |
-   | MLS_COMMIT        | Group | active | This document |
-   | MLS_APPLICATION   | Group | active | This document |
-   | MLS_REJOIN        | Group | active | This document |
-   +===================+=======+========+===============+
+   +===================+===========+===============+
+   | Notification Type | Scope     | Reference     |
+   +===================+===========+===============+
+   | MLS_WELCOME       | Recipient | This document |
+   | MLS_PROPOSAL      | Recipient | This document |
+   | MLS_COMMIT        | Recipient | This document |
+   | MLS_APPLICATION   | Recipient | This document |
+   | MLS_REJOIN        | Recipient | This document |
+   +===================+===========+===============+
 ~~~
 
 The following entry is to be registered in the "OCM Share Types"

--- a/IETF-OCM.md
+++ b/IETF-OCM.md
@@ -1342,20 +1342,27 @@ request:
 * REQUIRED notificationType (string) - it MUST be one of the
   registered values listed in the "OCM Notification Types"
   registry (see [IANA Considerations](#iana-considerations)).
-* REQUIRED senderDomain (string) - ...
-* REQUIRED resourceType (string) - ...
+* REQUIRED senderDomain (string) - the FQDN of the sender.  A Receiving
+  Server SHOULD use this information to verify the HTTP message
+  signature on the request, and it SHOULD also use it to validate the
+  underlying share or resource the notification is about.
+* OPTIONAL resourceType (string) - the type of the resource this
+  notification is about (e.g., `file`).
+* OPTIONAL shareType (string) - the type of recipient this notification
+  is about (e.g., `user`).
 * OPTIONAL providerId (string) - the identifier assigned by the
   Sending Server to the underlying share, if applicable. This
   field is _deprecated_ and SHOULD NOT be used.
 * OPTIONAL notification (object) - optional additional parameters,
   depending on the notification and the resource type.
 
-Multiple Notification types are defined for different purposes, and
-additional types MAY be defined by implementers and registered in the
-"OCM Notification Types" IANA Registry.  For each notification type,
-a specific format is defined for the optional notification object.
-In the sections below the base Notification types are detailed along
-with their specific payload.
+A Notification payload MUST include either the `resourceType` or the
+`shareType`, or both when relevant.  Multiple Notification types are
+defined for different purposes, and additional types MAY be defined
+by implementers and registered in the "OCM Notification Types" IANA
+Registry.  For each notification type, a specific format MAY be defined
+for the optional notification object.  In the sections below, the base
+Notification types are detailed along with their specific payload.
 
 ## Share Acceptance and Updating
 
@@ -1364,9 +1371,10 @@ the recipient accepted or declined a share, in response to a Share
 Creation Notification.  Similarly, it MAY be sent by a provider to let
 the recipient know that the provider updated or removed a given share,
 such that the recipient MAY clean it up from its database.  In all such
-cases, the `resourceType` is expected to match the `resourceType` of
-the underlying share (e.g., `file`), and the `notificationType` MUST be
-one of:
+cases, the `resourceType` MUST match the `resourceType` of the
+underlying share (e.g., `file`), the `shareType` MAY be omitted but if
+present it MUST match the `shareType` of the underlying share, and the
+`notificationType` MUST be one of:
 - "SHARE_ACCEPTED", to inform about the acceptance of a share.
 - "SHARE_DECLINED", to inform that a share was not accepted.
 - "SHARE_UNSHARED", to inform the Receiving Server that the share
@@ -1387,9 +1395,12 @@ Further, the `notification` object MUST include the following fields:
     the `permissions` values specified in the `webdav` protocol of a
     [Share Creation Notification](#share-creation-notification).
 
-Note that the Sending Server MAY at any time revoke access to a
-Resource (effectively undoing or deleting the Share) without notifying
-the Receiving Server.
+The same notifications identically apply to resources of type `folder`.
+For other resources with a different `resourceType` attribute, a
+Sending Server MAY implement the same notifications, provided that
+they get registered in the related IANA Registry.  Note that the
+Sending Server MAY at any time revoke access to a Resource (effectively
+undoing or deleting the Share) without notifying the Receiving Server.
 
 ## Resharing and Request to Share
 
@@ -1403,8 +1414,11 @@ the third party: in this case, all necessary exchanges and access
 requests MUST take place between the third party and the Sending
 Server, without further including the Receiving Server in the process.
 
-For a "REQUEST_RESHARE", the `notification` object MUST include the
-following fields:
+For a "REQUEST_RESHARE" notification, the `resourceType` MUST match the
+`resourceType` of the original share (e.g., `file`, `folder`, ...), the
+`shareType` MAY be omitted but if present it MUST match the `shareType`
+of the original share, and the the `notification` object MUST include
+the following fields:
 * OPTIONAL message (string) - an optional human-readable message that
   describes the request.
 * REQUIRED file (object) - an object containing the details of the
@@ -1428,8 +1442,10 @@ to the Sending Server.
 Similarly, the `"REQUEST_SHARE"` notification type MAY be used by a
 given Recipient OCM Server, to ask a remote OCM Server to share and
 grant access to a Resource, previously made known to the Recipient
-Server out of band.  In this case, the `notification` object MUST
-include the following fields:
+Server out of band.  In this case, the `resourceType` MUST match the
+`resourceType` of the Resource in question (e.g., `file`, `folder`,
+...), the `shareType` MUST be omitted, and the `notification` object
+MUST include the following fields:
 
 * OPTIONAL message (string) - an optional human-readable message that
   describes the request.
@@ -1460,6 +1476,7 @@ even informing the `owner`: in this case, it MUST respond to the
 `"REQUEST_SHARE"` notification with an appropriate HTTP response type
 such as HTTP 404.
 
+
 ## Recipient Removal
 
 A notification MAY be sent to inform a target OCM Server that a share
@@ -1471,9 +1488,10 @@ The recipient of such notification MAY reciprocally remove that
 recipient from the list of trusted users, along with any related
 shares.
 
-For these cases, a notification payload MUST be formed such that the
-`resourceType` is set to the affected shareType being removed, such as
-`user` or `group`, and the `notificationType` MUST be one of:
+For these cases, a notification payload is to be formed such that the
+`resourceType` MUST be omitted, the `shareType` is set to the affected
+shareType being removed, such as `user` or `group`, and the
+`notificationType` MUST be one of:
 - "USER_REMOVED", to inform about a single user that was removed or
   marked as not trusted.
 - "GROUP_REMOVED", to inform about a removed group.

--- a/IETF-OCM.md
+++ b/IETF-OCM.md
@@ -256,7 +256,6 @@ provide a _WAYF Page_ to facilitate the Invite Flow.  The WAYF page MAY
 be limited to a set of trusted OCM Providers, for instance those in the
 same _Federation_.
 
-
 ### Receiving Server
 
 A Receiving Server is an OCM Provider that receives _Share_ Creation
@@ -1113,7 +1112,7 @@ described in [OCM-IP].
   the protocol.
   Option 3: Set the `name` field to `multi`, and put the
   protocol details in a field carrying the name of the protocol.
-  Option 1 using the `options` field is now deprecated.
+  Option 1 using the `options` field is _deprecated_.
   Implementations are encouraged to transition to the new
   optional properties defined below, such that this field
   may be removed in a future major version of the spec.
@@ -1126,7 +1125,7 @@ described in [OCM-IP].
   supported, and its options MAY be given in the opaque
   `options` payload for compatibility with v1.0
   implementations (see examples).  Note though that this
-  format is deprecated.
+  format is _deprecated_.
   Warning: client implementers should be aware that v1.1+
   servers MAY support both `webdav` and `multi`, but v1.0
   servers MAY only support `webdav`.
@@ -1321,57 +1320,17 @@ They could give the Receiving Party the option to accept or reject the
 share, or add the share automatically and only send an informational
 notification that this happened.
 
-# Request for a Share
 
-If the Receiving Party knows of a resource that has not yet
-been shared, the Receiving Party MAY request that it be shared.
-Such a Request for a Share MUST be an HTTP POST request
+# Notifications
 
-* to the `/request-share` path in the Sending Server's OCM API
-* using `application/json` as the `Content-Type` HTTP request
-  header
-* its request body containing a JSON document representing an
-  object with the fields as described below
-* using TLS
+This optional endpoint is used to inform the other party about a change
+that concerns a previously known entity, such as a Resource or a
+trusted Share type (e.g. a user).
 
-When HTTP Message Signatures are available, the Request for a Share
-MUST be signed and verified as described in [HTTP Message
-Signatures](#http-message-signatures).  As requesting access to a
-restricted resource relies on authenticating the requester,
-implementations SHOULD NOT use this feature unless signing is
-available.
+A Server that intends to send a notification SHOULD make a HTTP POST
+request:
 
-## Fields
-
-* REQUIRED owner (string)
-  OCM Address of the user who will be requested to share the resource.
-* REQUIRED shareWith (string)
-  OCM Address of the user or group that wants to receive a share of
-  the resource.
-  Example: "51dc30ddc473d43a6011e9ebba6ca770@cloud.example.org"
-* REQUIRED share (string)
-  A unique identifier for the resource.
-  Example: 1234567890abcdef or https://cloud.example.org/files/data.txt
-
-Any HTTP Signature on the Request for a Share is verified as described
-in [HTTP Message Signatures](#http-message-signatures) before the
-Sending Server acts on it.
-
-After receiving a request for a Share, the Sending Party MAY
-send a Share Creation Notification to the Receiving Party
-using the OCM address in the shareWith field.
-
-
-# Share Acceptance Notification
-
-In response to a Share Creation Notification, the Receiving Server MAY
-discover the OCM API of the Sending Server, starting from the `<fqdn>`
-part of the `sender` field in the Share Creation Notification.
-
-If the OCM API of the Sending Server is successfully discovered, the
-Receiving Server MAY make a HTTP POST request
-
-* to the `/notifications` path in the Sending Server's OCM API
+* to the `/notifications` path in the Receiving Server's OCM API
 * using `application/json` as the `Content-Type` HTTP request header
 * its request body containing a JSON document representing an object
   with the fields as described below
@@ -1380,35 +1339,155 @@ Receiving Server MAY make a HTTP POST request
 
 ## Fields
 
-* REQUIRED notificationType (string) - in a Share Acceptance
-  Notification it MUST be one of:
-  - 'SHARE_ACCEPTED'
-  - 'SHARE_DECLINED'
-  Registered values are listed in the "OCM Notification Types"
+* REQUIRED notificationType (string) - it MUST be one of the
+  registered values listed in the "OCM Notification Types"
   registry (see [IANA Considerations](#iana-considerations)).
-* REQUIRED providerId (string) - copied from the Share Creation
-  Notification for the Share this notification is about
-* OPTIONAL resourceType (string) - copied from the Share Creation
-  Notification for the Share this notification is about
+* REQUIRED senderDomain (string) - ...
+* REQUIRED resourceType (string) - ...
+* OPTIONAL providerId (string) - the identifier assigned by the
+  Sending Server to the underlying share, if applicable. This
+  field is _deprecated_ and SHOULD NOT be used.
 * OPTIONAL notification (object) - optional additional parameters,
-  depending on the notification and the resource type
+  depending on the notification and the resource type.
 
-For example, a notification MAY be sent by a recipient to let the
-provider know that the recipient declined a share.  In this case, the
-provider site MAY mark the share as declined for its user(s).
-Similarly, it MAY be sent by a provider to let the recipient know that
-the provider removed a given share, such that the recipient MAY clean
-it up from its database.  A notification MAY also be sent to let a
-recipient know that the provider removed that recipient from the list
-of trusted users, along with any related share.  The recipient MAY
-reciprocally remove that provider from the list of trusted users, along
-with any related share.
+Multiple Notification types are defined for different purposes, and
+additional types MAY be defined by implementers and registered in the
+"OCM Notification Types" IANA Registry.  For each notification type,
+a specific format is defined for the optional notification object.
+In the sections below the base Notification types are detailed along
+with their specific payload.
 
-Notifications from Sending Server to Receiving Server SHOULD use
-httpsig [RFC9421] so the Receiving Server can authenticate the origin
-of the notification.  Receiving Servers SHOULD decline notifications
-from Sending Servers without httpsig as it can't identify where the
-notification is coming from.
+## Share Acceptance and Updating
+
+A notification MAY be sent by a recipient to let the provider know that
+the recipient accepted or declined a share, in response to a Share
+Creation Notification.  Similarly, it MAY be sent by a provider to let
+the recipient know that the provider updated or removed a given share,
+such that the recipient MAY clean it up from its database.  In all such
+cases, the `resourceType` is expected to match the `resourceType` of
+the underlying share (e.g., `file`), and the `notificationType` MUST be
+one of:
+- "SHARE_ACCEPTED", to inform about the acceptance of a share.
+- "SHARE_DECLINED", to inform that a share was not accepted.
+- "SHARE_UNSHARED", to inform the Receiving Server that the share
+  was removed and is not accessible any longer.
+- "SHARE_CHANGE_PERMISSION", to inform the Receiving Server that
+  the permissions of a share were updated.
+Further, the `notification` object MUST include the following fields:
+* OPTIONAL message (string) - an optional human-readable message that
+  describes the event.
+* REQUIRED file (object) - an object containing the details of the
+  event, including:
+  * REQUIRED providerId (string) - the unique identifier assigned
+    by the Sending Server to the underlying share in a previous Share
+    Creation Notification.
+  * OPTIONAL permissions (array of strings) - The permissions granted
+    to the sharee, in case they have changed in the context of a
+    `SHARE_CHANGE_PERMISSION` notification.  The allowed values match
+    the `permissions` values specified in the `webdav` protocol of a
+    [Share Creation Notification](#share-creation-notification).
+
+Note that the Sending Server MAY at any time revoke access to a
+Resource (effectively undoing or deleting the Share) without notifying
+the Receiving Server.
+
+## Resharing and Request to Share
+
+The "REQUEST_RESHARE" notification type MAY be used by the Receiving
+Server to ask the Sending Server to share a given, previously shared
+Resource, with another third Receiving Party.  The Sending Server MAY
+discard this request, e.g. in case the third party is not trusted, or
+the share was originally granted without a `share` permission.  If
+the Sending Server accepts the request, it MUST create a new share to
+the third party: in this case, all necessary exchanges and access
+requests MUST take place between the third party and the Sending
+Server, without further including the Receiving Server in the process.
+
+For a "REQUEST_RESHARE", the `notification` object MUST include the
+following fields:
+* OPTIONAL message (string) - an optional human-readable message that
+  describes the request.
+* REQUIRED file (object) - an object containing the details of the
+  request, including:
+  * REQUIRED providerId (string) - the unique identifier assigned
+    by the Sending Server to the underlying share in a previous Share
+    Creation Notification.
+  * REQUIRED shareWith (string) - the OCM Address of the third party
+    the underlying share should be reshared with.
+  * OPTIONAL permissions (array of strings) - The permissions to be
+    granted to the third party.  The allowed values match the
+    `permissions` values specified in the `webdav` protocol of a
+    [Share Creation Notification](#share-creation-notification).
+
+The Receiving Server SHOULD receive a response whether the reshare
+request was fulfilled or not.  In any case, a Receiving Server MUST
+NOT directly reshare a Resource, even when a `share` permission was
+granted, and MUST always send a `"REQUEST_RESHARE"` Notification
+to the Sending Server.
+
+Similarly, the `"REQUEST_SHARE"` notification type MAY be used by a
+given Recipient OCM Server, to ask a remote OCM Server to share and
+grant access to a Resource, previously made known to the Recipient
+Server out of band.  In this case, the `notification` object MUST
+include the following fields:
+
+* OPTIONAL message (string) - an optional human-readable message that
+  describes the request.
+* REQUIRED file (object) - an object containing the details of the
+  request, including:
+  * REQUIRED owner (string) - OCM Address of the user who will be
+    requested to share the resource.
+  * REQUIRED shareWith (string) - OCM Address of the recipient that
+    wishes to receive a share of the resource.
+    Example: "51dc30ddc473d43a6011e9ebba6ca770@cloud.example.org"
+  * REQUIRED shareId (string) - A unique identifier for the resource.
+    Example: https://cloud.example.org/files/data.txt or
+    1234567890abcdef.
+  * REQUIRED permissions (array of strings) - The permissions to be
+    granted to the requesting party.  The allowed values match the
+    `permissions` values specified in the `webdav` protocol of a
+    [Share Creation Notification](#share-creation-notification).
+
+The remote OCM Server MAY choose to fulfill the request, according
+to its trust policies: in that case, it MUST respond with HTTP 201
+to the caller, and asynchronously ask for permission to the `owner`
+user.  If the owner agrees, it MUST send a
+[Share Creation Notification](#share-creation-notification) including
+the `shareWith` user as recipient, whereas if the owner disagrees,
+it MUST send back a `"SHARE_DECLINED"` notification.  The remote OCM
+Server MAY also decline such request because of its policies, without
+even informing the `owner`: in this case, it MUST respond to the
+`"REQUEST_SHARE"` notification with an appropriate HTTP response type
+such as HTTP 404.
+
+## Recipient Removal
+
+A notification MAY be sent to inform a target OCM Server that a share
+recipient (e.g. a user or group) was removed from the list of trusted
+users, following a previous successful Invitation, or otherwise left
+the system.  That recipient may have been previously known to the
+target server because of existing shares whose shareType matched it.
+The recipient of such notification MAY reciprocally remove that
+recipient from the list of trusted users, along with any related
+shares.
+
+For these cases, a notification payload MUST be formed such that the
+`resourceType` is set to the affected shareType being removed, such as
+`user` or `group`, and the `notificationType` MUST be one of:
+- "USER_REMOVED", to inform about a single user that was removed or
+  marked as not trusted.
+- "GROUP_REMOVED", to inform about a removed group.
+Further, the `notification` object MUST include the following fields:
+* OPTIONAL message (string) - an optional human-readable message that
+  describes the event.
+* REQUIRED user or group (object) - an object containing the details
+  of the recipient to be removed. In case of `user`, it MUST include:
+  * REQUIRED userId (string) - OCM Address of the user to be removed
+    from the target OCM Server.
+  Whereas in case of `group`, it MUST include:
+  * REQUIRED groupId (string) - identifier of the group to be removed
+    from the target OCM Server.
+
 
 # Resource Access
 
@@ -1503,7 +1582,7 @@ through OCM.  The mechanism is aligned with the OAuth 2.0
 server to server interaction between the Sending and Receiving Servers.
 No user interaction or redirect is involved. [RFC6749]
 
-##  Token Request
+## Token Request
 
 To obtain an access token, the Receiving Server MUST send an HTTP POST
 request to the Sending Server’s {tokenEndPoint} as discovered in the
@@ -1537,7 +1616,7 @@ Share Creation Notification.  It is allowed to send the additional
 parameters defined in [RFC6749] for the `authorization_code` grant type,
 but they MUST be ignored.
 
-##  Token Response
+## Token Response
 
 If the request is valid and the code is accepted, the Sending Server
 MUST respond with HTTP 200 OK and a OAuth-compliant JSON object
@@ -1561,7 +1640,7 @@ the same request to the {tokenEndPoint} MUST be repeated before the
 `access_token` has expired, to recieve a new `access_token` that can
 then be used in the same manner.
 
-##  Error Responses
+## Error Responses
 
 If the request is invalid, the Sending Server MUST return an HTTP 400
 response with a JSON object containing an OAuth 2.0 error code
@@ -1631,36 +1710,6 @@ The following examples illustrate typical end-to-end outcomes:
     legacy access.  A therefore accepts strict inbound shares while
     still choosing a legacy-compatible outbound share.
 
-# Share Deletion
-
-A `"SHARE_ACCEPTED"` notification followed by a `"SHARE_UNSHARED"`
-notification is equivalent to a `"SHARE_DECLINED"` notification.
-
-Note that the Sending Server MAY at any time revoke access to a
-Resource (effectively undoing or deleting the Share) without notifying
-the Receiving Server.
-
-# Share Updating
-
-Some implementations have experimented with a
-`"RESHARE_CHANGE_PERMISSION"`notification, but the payload and side
-effects such a notification may have are out of scope of this version
-of this specification.
-The Receiving Party sending such a notification has no way of knowing
-if the Sending Party understood and processed the reshare request
-or not.
-
-# Resharing
-
-The `"REQUEST_RESHARE"` and `"RESHARE_UNDO"` notification types MAY be
-used by the Receiving Server to persuade the Sending Server to share the
-same Resource with another Receiving Party.
-The details of the payload and side effects such a notification may
-have are out of scope of this version of this specification.
-Note that the Receiving Party sending such a notification has no way of
-knowing if the Sending Party understood and processed the reshare
-request or not.  In all cases, the Receiving Server MUST NOT reshare
-a Resource without an explicit grant from the Sending Server.
 
 # IANA Considerations
 
@@ -1945,27 +1994,32 @@ IANA is requested to create the "OCM Notification Types" registry in
 the "Open Cloud Mesh (OCM) Parameters" group.  This registry records
 the values that MAY appear in the "notificationType" field of an OCM
 notification sent to the "/notifications" endpoint (see
-[Share Acceptance Notification](#share-acceptance-notification)).
+[Notifications](#notifications)).
 
-The "Scope" field indicates whether the notification refers to a Share,
-in which case the "providerId" field is REQUIRED, or to a Group.  The
-"Status" field is one of "active" or "experimental".
+The "Scope" field indicates whether the notification refers to a
+Resource, in which case the "providerId" field is REQUIRED in the
+payload, or to a Recipient, i.e. to the shareType in a
+[Share Creation Notification](#share-creation-notification), in which
+case a corresponding identifier such as "userId" is REQUIRED in the
+payload.
 
    Registration Policy: Specification Required [RFC8126]
 
    Initial Contents:
 
 ~~~
-   +===========================+=======+==============+===============+
-   | Notification Type         | Scope | Status       | Reference     |
-   +===========================+=======+==============+===============+
-   | SHARE_ACCEPTED            | Share | active       | This document |
-   | SHARE_DECLINED            | Share | active       | This document |
-   | SHARE_UNSHARED            | Share | active       | This document |
-   | REQUEST_RESHARE           | Share | experimental | This document |
-   | RESHARE_UNDO              | Share | experimental | This document |
-   | RESHARE_CHANGE_PERMISSION | Share | experimental | This document |
-   +===========================+=======+==============+===============+
+   +===========================+===========+===============+
+   | Notification Type         | Scope     | Reference     |
+   +===========================+===========+===============+
+   | SHARE_ACCEPTED            | Resource  | This document |
+   | SHARE_DECLINED            | Resource  | This document |
+   | SHARE_UNSHARED            | Resource  | This document |
+   | SHARE_CHANGE_PERMISSION   | Resource  | This document |
+   | REQUEST_RESHARE           | Resource  | This document |
+   | REQUEST_SHARE             | Resource  | This document |
+   | USER_REMOVED              | Recipient | This document |
+   | GROUP_REMOVED             | Recipient | This document |
+   +===========================+===========+===============+
 ~~~
 
 # Security Considerations
@@ -2733,6 +2787,10 @@ The complete changelog is updated in the OCM-API GitHub repository.
   Index](#signing-direction-index), [Appendix E: Navigation
   Index](#appendix-e-navigation-index), and companion diagrams under
   `diagrams/` in the OCM-API repository.
+* Rehaul of the Notification (formerly "Share Acceptance
+  Notification") endpoint and payload, and adaptation of the IANA
+  registries.  The core notifications have now been fully spelled
+  out, clarifying their scope.
 
 ## Version 06
 * Introduced IANA Registries for resource types, protocols, share

--- a/spec.yaml
+++ b/spec.yaml
@@ -907,9 +907,7 @@ components:
       type: object
       required:
         - notificationType
-        - resourceType
         - senderDomain
-        - notification
       properties:
         notificationType:
           type: string
@@ -919,18 +917,25 @@ components:
             Any value registered in the OCM IANA Registry for notification types
             MAY be used here. Implementers MAY define additional custom types,
             provided that they are registered in the OCM IANA Registry.
-        resourceType:
-          type: string
-          description: >
-            Resource type or share type, according to the OCM IANA Registry
-            for resource types and share types. E.g. file, folder, user, calendar,
-            contact, etc. Implementers MAY define additional custom types, provided
-            that they are registered in the respective OCM IANA Registry.
         senderDomain:
           type: string
           description: >
             The FQDN of the sending OCM server, in order for the recipient
             to validate its key material when verifying the HTTP Signature.
+        resourceType:
+          type: string
+          description: >
+            Resource type, according to the OCM IANA Registry for resource types.
+            E.g. file, folder, calendar, contact, etc. Implementers MAY define
+            additional custom types, provided that they are registered in the
+            respective OCM IANA Registry.
+        shareType:
+          type: string
+          description: >
+            Share type, according to the OCM IANA Registry for share types.
+            E.g. user, group, federation, etc. Implementers MAY define
+            additional custom types, provided that they are registered in the
+            respective OCM IANA Registry.
         providerId:
           type: string
           description: >
@@ -966,14 +971,15 @@ components:
         shareWasAccepted:
           notificationType: SHARE_ACCEPTED
           resourceType: file
-          senderDomain: sender.org
+          shareType: user
+          senderDomain: sender.example.org
           notification:
             message: Recipient accepted the share
             file:
               providerId: 7c084226-d9a1-11e6-bf26-cec0c932ce01
         userWasRemoved:
           notificationType: USER_REMOVED
-          resourceType: user
+          shareType: user
           senderDomain: alice.example.org
           notification:
             message: User is not a trusted contact any longer
@@ -981,7 +987,7 @@ components:
               userId: alice@alice.example.org
         mlsWelcome:
           notificationType: MLS_WELCOME
-          resourceType: federation
+          shareType: federation
           senderDomain: cloud.example.org
           notification:
             federation:

--- a/spec.yaml
+++ b/spec.yaml
@@ -35,62 +35,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Discovery"
-  /request-share:
-    post:
-      summary: Request access to a share
-      description: >
-        This endpoint is used to request access to a share.
-        The request MUST contain the share ID and the OCM address of the party
-        who wants to receive the share.
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/RequestShare"
-        description: The JSON object to request access to a share.
-        required: true
-      responses:
-        "201":
-          description: >
-            Consumer successfully received request.
-        "400":
-          description: >
-            Bad request due to invalid or missing parameters.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/400"
-        "404":
-          description: >
-            The requested `share` is missing, or the requestor does not have
-            rights to access it.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Error"
-        "501":
-          description: The server doesn't support requesting shares.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Error"
-        "503":
-          description: The server is temporary unavailable (e.g. due to planned
-            maintenance).
-          headers:
-            Retry-After:
-              description: >
-                Indication for the client when the service could be requested
-                again in HTTP Date format as used by the Internet Message
-                Format [RFC5322] (e.g. `Wed, 21 Oct 2015 07:28:00 GMT`) or the
-                number of seconds (e.g. 3000 if you the service is expected to
-                be available again within 50 minutes).
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Error"
   /shares:
     post:
       summary: Share Creation Notification endpoint
@@ -174,11 +118,13 @@ paths:
                 $ref: "#/components/schemas/Error"
   /notifications:
     post:
-      summary: Share Acceptance Notification endpoint
+      summary: General Notification endpoint
       description: >
         This optional endpoint is used to inform the other party about a change
-        that concerns a previously known entity, such as a Share or a trusted User.
-        See [Share Acceptance Notification](https://datatracker.ietf.org/doc/html/draft-ietf-ocm-open-cloud-mesh#share-acceptance-notification)
+        that concerns a previously known entity, such as a Share or a trusted User,
+        or to request an action to be performed (such as sharing or re-sharing)
+        on a previously known resource.
+        See [Notifications](https://datatracker.ietf.org/doc/html/draft-ietf-ocm-open-cloud-mesh#notifications)
         for more details.
       requestBody:
         content:
@@ -191,30 +137,34 @@ paths:
         "201":
           description: >
             Receiver succesfully received the notification. The response body
-            MAY contain
-            a JSON object with some resonse data, depending on the actual notification.
+            MAY contain a JSON object with response data, depending on
+            the actual notification.
         "400":
-          description: |
-            Bad request due to invalid parameters, e.g. when `type` is invalid
-            or missing.
+          description: >
+            Bad request due to invalid parameters, e.g. when `notificationType` is
+            invalid, not known or missing.
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/400"
         "401":
-          description: Client cannot be authenticated as a trusted service.
+          description: Requestor cannot be authenticated.
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
         "403":
-          description: Trusted service is not authorized to create notifications.
+          description: Requestor is not authorized to send notifications.
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+        "404":
+          description: >
+            The notification refers to a missing target (share, user, etc.), or the requestor
+            does not have rights to access it.
         "501":
-          description: |
+          description: >
             The receiver doesn't support notifications, the resource type is not
             supported.
           content:
@@ -222,12 +172,12 @@ paths:
               schema:
                 $ref: "#/components/schemas/Error"
         "503":
-          description: |
+          description: >
             The receiver is temporary unavailable (e.g. due to planned
             maintenance).
           headers:
             Retry-After:
-              description: |
+              description: >
                 Indication for the client when the service could be requested
                 again in HTTP Date format as used by the Internet Message Format
                 [RFC5322] (e.g. `Wed, 21 Oct 2015 07:28:00 GMT`) or the number
@@ -675,17 +625,16 @@ components:
                 its options MAY be given in the opaque `options` payload for
                 compatibility with v1.0 implementations (see examples). Note
                 though that this format is deprecated.
-                Warning: client implementers should be aware that v1.1 servers
+                Warning: client implementers should be aware that v1.1+ servers
                 MAY support both `webdav` and `multi`, but v1.0 servers MAY
                 only support `webdav`.
-                This field may be removed in a future major version of the spec.
+                This field may be removed in a future version of the spec.
             options:
               type: object
               description: >
-                This property is now deprecated. Implementations are
-                encouraged to
+                This property is now deprecated. Implementations are encouraged to
                 transition to the new optional properties defined below, such that
-                this field may be removed in a future major version of the spec.
+                this field may be removed in a future version of the spec.
             webdav:
               type: object
               required:
@@ -917,7 +866,7 @@ components:
               options:
                 sharedSecret: hfiuhworzwnur98d3wjiwhr
                 permissions: some permissions scheme
-            singleProtocolNew:
+            singleProtocol:
               name: multi
               webdav:
                 uri: 7c084226-d9a1-11e6-bf26-cec0c932ce01
@@ -959,46 +908,86 @@ components:
       required:
         - notificationType
         - resourceType
-        - providerId
+        - senderDomain
+        - notification
       properties:
         notificationType:
           type: string
-          description: |
+          description: >
             A notification type that is understandable for both humans and
-            machines (e.g. no use of special characters) providing more
-            information on the cause of the error.
-            Values that MAY be used by implementations are:
-            `SHARE_ACCEPTED`, `SHARE_DECLINED`, `REQUEST_RESHARE`,
-            `SHARE_UNSHARED`, `RESHARE_UNDO`, `RESHARE_CHANGE_PERMISSION`,
-            `USER_REMOVED`.
+            machines, providing information about an event.
+            Any value registered in the OCM IANA Registry for notification types
+            MAY be used here. Implementers MAY define additional custom types,
+            provided that they are registered in the OCM IANA Registry.
         resourceType:
           type: string
-          description: |
-            Resource type (file, folder, user, calendar, contact, ...)
+          description: >
+            Resource type or share type, according to the OCM IANA Registry
+            for resource types and share types. E.g. file, folder, user, calendar,
+            contact, etc. Implementers MAY define additional custom types, provided
+            that they are registered in the respective OCM IANA Registry.
+        senderDomain:
+          type: string
+          description: >
+            The FQDN of the sending OCM server, in order for the recipient
+            to validate its key material when verifying the HTTP Signature.
         providerId:
           type: string
-          description: |
-            Identifier of the shared resource. If the resourceType is `file`,
-            then see `NewShare/providerId` for the required information.
-            If the resourceType is `user`, then this is the user identifier
-            previously sent via `/invite-accepted`.
+          description: >
+            Optional unique identifier of the underlying resource. This property
+            is now deprecated, in favor of including it in the notification object.
         notification:
           type: object
-          description: |
+          description: >
             Optional additional parameters, depending on the notification
-            and the resource type.
+            and the resource type or share type in question.
+          properties:
+            message:
+              type: string
+              description: >
+                An optional human-readable message that describes the event.
+          additionalProperties:
+            type: object
+            description: >
+              This object MUST be keyed with the resource type or share type of this
+              notification. It contains its payload and it can vary according to the
+              implementers. In case of `file` resources, it MUST contain at least the
+              `providerId` of the underlying resource, and in case of `user`, `group`,
+              or `federation` share types, it MUST contain at least the `userId`,
+              `groupId`, or `mlsGroupId` of the underlying recipient, respectively.
       example:
-        shareWasAccepted:
+        legacyShareWasAccepted:
           notificationType: SHARE_ACCEPTED
           resourceType: file
           providerId: 7c084226-d9a1-11e6-bf26-cec0c932ce01
           notification:
             message: Recipient accepted the share
             sharedSecret: hfiuhworzwnur98d3wjiwhr
+        shareWasAccepted:
+          notificationType: SHARE_ACCEPTED
+          resourceType: file
+          senderDomain: sender.org
+          notification:
+            message: Recipient accepted the share
+            file:
+              providerId: 7c084226-d9a1-11e6-bf26-cec0c932ce01
         userWasRemoved:
           notificationType: USER_REMOVED
           resourceType: user
-          providerId: 51dc30ddc473d43a6011e9ebba6ca770
+          senderDomain: alice.example.org
+          notification:
+            message: User is not a trusted contact any longer
+            user:
+              userId: alice@alice.example.org
+        mlsWelcome:
+          notificationType: MLS_WELCOME
+          resourceType: federation
+          senderDomain: cloud.example.org
+          notification:
+            federation:
+              mlsGroupId: 51dc30ddc473d43a6011e9ebba6ca770
+              userId: bob@cloud.example.org
+              content: base64 MLS welcome
     AcceptedInvite:
       type: object
       required:


### PR DESCRIPTION
Main areas:
- Notification payloads are fully specified in case of `file` resources or shareType (`user`, etc.) recipients
- Request to share is now a notification
- Reshare operations are better explained, including the fact that access must always happen to the owner's server, not via third parties. At the moment, this implies that even if Bob received a share with `share` permission, Bob cannot send the share to Charlie right away and MUST send Alice a `REQUEST_RESHARE` notification, to ask Alice to share the same resource to Charlie.

Still missing:
- The format of a notification response when successful is left unspecified
- A `FEDERATION_REMOVED` notification is not specified, do we need it?
- The payloads of each notification type are specified in the I-Ds but not in `spec.yaml`. To be seen if we want to have satellite OpenAPI specs for them.

I acknowledge this is quite a large single commit. If needed I can extract the request to share part, but as it came through the editing it was not obvious to take it apart.