### PR TITLE
Move encryption to the main I-D

### DIFF
--- a/IETF-OCM-MLS.md
+++ b/IETF-OCM-MLS.md
@@ -1587,19 +1587,22 @@ Each notification MAY include the optional `encryption` field:
   },
   "encryption": {
     "resourceId": "3a02538b-aa54-42f2-8853-a38996e211b1"
-    "scheme": "ocm-mls-1",
-    "cipher": "AES-256-GCM",
+    "scheme": "ocm-mls",
+    "ocm-mls": {
+      "cipher": "AES-256-GCM",
+    }
   }
 }
 ~~~
 
 The `encryption` field is OPTIONAL as per [OCM] Share Creation
 Notification specification.  If absent, the resource is unencrypted.
-If present, it MUST carry the encryption-related parameters according
-to the [OCM] specification, where:
+If present, and the symmetric encryption available via OCM-MLS is to
+be used, it MUST carry the encryption-related parameters according to
+the [OCM] specification, where:
 - `resourceId` is the stable resource identifier described in
 {{resource-id}}
-- `scheme` is to be set to `"ocm-mls-1"`
+- `scheme` is to be set to `"ocm-mls"`
 - `cipher` names the content AEAD that the resource is encrypted with
 ({{file-key-wrapping}}), one of the AEAD algorithms defined for HPKE
 ([RFC9180] Section 7.3): `"AES-128-GCM"`, `"AES-256-GCM"`, or
@@ -2011,6 +2014,20 @@ registrations do not modify the protocols' own registrations:
    | folder        | federation | webdav, webapp, ssh | This document |
    +===============+============+=====================+===============+
 ~~~
+
+The following entries are to be registered in the "OCM Encryption
+Schemes" registry defined in [OCM], within the "Open Cloud Mesh (OCM)
+Parameters" group:
+
+~~~
+   +=========+============+===============+
+   | Scheme  | Share Type | Reference     |
+   +=========+============+===============+
+   | ocm-pgp | federation | This document |
+   | ocm-mls | federation | This document |
+   +=========+============+===============+
+~~~
+
 
 # Open Issues
 

--- a/IETF-OCM-MLS.md
+++ b/IETF-OCM-MLS.md
@@ -380,10 +380,7 @@ with `shareWith` carrying the group's OCM Address.  A federation share
 is otherwise a standard OCM share, carrying every field REQUIRED by
 [OCM] including the `protocol` object.  All new server-to-server
 messages use the existing `/notifications` endpoint with new
-`notificationType` values.  A single new field is added to the Share
-Creation Notification: `encryption` (optional, present only for
-encrypted resources), carrying all encryption-related parameters,
-including the `resourceId`.
+`notificationType` values.
 
 # Discovery
 
@@ -1099,14 +1096,14 @@ a given epoch.
 The `resourceId` used in the AEAD associated data MUST be a stable
 identifier for the underlying file, consistent across all groups it is
 shared with.  It identifies the resource, not a particular version of
-it. This ensures that the FK unwrapped by members of any group correctly
-decrypts the same ciphertext.  The `providerId` values in separate share
-notifications, for the same resource, MUST differ, per the `providerId`
-definition in [OCM], but the `resourceId` in the AEAD associated data
-MUST be the same.  This means that the `providerId` MUST NOT be reused
-as `resourceId`.  The sending server is responsible for maintaining this
-stable `resourceId` and MUST send it in the `encryption` object of the
-share payload ({{share-creation}}).
+it or a specific share.  This ensures that the FK unwrapped by members
+of any group correctly decrypts the same ciphertext.  The `providerId`
+values in separate share notifications, for the same resource, MUST
+differ, per the `providerId` definition in [OCM], but the `resourceId`
+in the AEAD associated data MUST be the same.  This means that the
+`providerId` MUST NOT be reused as `resourceId`.  The sending server is
+responsible for maintaining this stable `resourceId` and MUST send it
+in the `encryption` object of the share payload ({{share-creation}}).
 
 ## File Key Wrapping {#file-key-wrapping}
 
@@ -1589,20 +1586,21 @@ Each notification MAY include the optional `encryption` field:
     }
   },
   "encryption": {
+    "resourceId": "3a02538b-aa54-42f2-8853-a38996e211b1"
     "scheme": "ocm-mls-1",
     "cipher": "AES-256-GCM",
-    "resourceId": "3a02538b-aa54-42f2-8853-a38996e211b1"
   }
 }
 ~~~
 
-The `encryption` field is OPTIONAL.  If absent, the resource is
-unencrypted and the share follows the standard OCM flow without
-modification.  If present, it carries all encryption-related parameters:
-`scheme` identifies the encryption scheme, for which this document
-defines `"ocm-mls-1"`; `resourceId` is the stable resource identifier
-described in {{resource-id}}; and `cipher` (REQUIRED when `encryption`
-is present) names the content AEAD that the resource is encrypted with
+The `encryption` field is OPTIONAL as per [OCM] Share Creation
+Notification specification.  If absent, the resource is unencrypted.
+If present, it MUST carry the encryption-related parameters according
+to the [OCM] specification, where:
+- `resourceId` is the stable resource identifier described in
+{{resource-id}}
+- `scheme` is to be set to `"ocm-mls-1"`
+- `cipher` names the content AEAD that the resource is encrypted with
 ({{file-key-wrapping}}), one of the AEAD algorithms defined for HPKE
 ([RFC9180] Section 7.3): `"AES-128-GCM"`, `"AES-256-GCM"`, or
 `"CHACHA20-POLY1305"`.  The field signals that the FK is distributed via
@@ -1611,7 +1609,7 @@ epoch information is carried in the share notification.  Member Servers
 always hold the current wrapped FK for each `(resourceId, groupId)` pair
 and use their current Group Key to unwrap it at access time.
 
-The Group Owner Server is not involved in the delivery of OCM share
+The Group Owner Server is not involved in the delivery of OCM Share
 notifications.  All other OCM notifications relating to a share, such as
 share updates and share deletions, are likewise sent directly from the
 sending server to each Member Server, referencing the share by its

--- a/IETF-OCM.md
+++ b/IETF-OCM.md
@@ -1100,9 +1100,17 @@ described in [OCM-IP].
   - REQUIRED resourceId (string) - a unique identifier of the
     underlying resource.
   - REQUIRED scheme (string) - an identifier of the encryption scheme
-    used to encrypt the resource, such as "ocm-pgp-1".
-  - REQUIRED cipher (string) - the encryption algorithm used to encrypt
-    the resource as in [RFC9180] Section 7.3.
+    used to encrypt the resource, such as "ocm-pgp".  Registered values
+    are listed in the "OCM Encryption Schemes" registry (see
+    [IANA Considerations](#iana-considerations)).
+  - REQUIRED {schemeObject} (object) - an object keyed with the given
+    scheme, containing the details of the encryption used.
+    For the "ocm-gpg" scheme, it MUST contain:
+    - fingerprints (array of strings) - one or more fingerprints of
+      the public keys used to encrypt the resource.
+    For the "ocm-mls" scheme, it MUST contain:
+    - cipher (string) - the encryption algorithm used to encrypt the
+      resource as in [RFC9180] Section 7.3.
 * REQUIRED protocol (object)
   JSON object with specific options for each protocol.
   The supported protocols are:
@@ -1886,7 +1894,7 @@ policy for each registry in this group is "Specification Required"
 is documented in a stable, publicly available specification and that it
 does not duplicate an existing entry.
 
-## OCM Resource Types Registry
+### OCM Resource Types Registry
 
 IANA is requested to create the "OCM Resource Types" registry in the
 "Open Cloud Mesh (OCM) Parameters" group.  This registry records the
@@ -1908,7 +1916,7 @@ the [OCM API Discovery](#ocm-api-discovery) endpoint.
    +===============+=====================+===============+
 ~~~
 
-## OCM Protocols Registry
+### OCM Protocols Registry
 
 IANA is requested to create the "OCM Protocols" registry in the "Open
 Cloud Mesh (OCM) Parameters" group.  Each entry records a protocol
@@ -1942,7 +1950,7 @@ for a given resource type and share type is governed by the
    +================+=========+===============+
 ~~~
 
-## OCM Share Types Registry
+### OCM Share Types Registry
 
 IANA is requested to create the "OCM Share Types" registry in the
 "Open Cloud Mesh (OCM) Parameters" group.  Each entry records a share
@@ -1966,7 +1974,7 @@ The "federation" share type, for example, is registered by [OCM-MLS].
    +============+===============+
 ~~~
 
-## OCM Share Payloads Registry
+### OCM Share Payloads Registry
 
 IANA is requested to create the "OCM Share Payloads" registry in the
 "Open Cloud Mesh (OCM) Parameters" group.  Whereas the "OCM Resource
@@ -2017,7 +2025,7 @@ interoperable way, they can do so using this very mechanism.
    +===============+============+=====================+===============+
 ~~~
 
-## OCM Notification Types Registry
+### OCM Notification Types Registry
 
 IANA is requested to create the "OCM Notification Types" registry in
 the "Open Cloud Mesh (OCM) Parameters" group.  This registry records
@@ -2049,6 +2057,26 @@ payload.
    | USER_REMOVED              | Recipient | This document |
    | GROUP_REMOVED             | Recipient | This document |
    +===========================+===========+===============+
+~~~
+
+### OCM Encryption Schemes Registry
+
+IANA is requested to create the "OCM Encryption Schemes" registry in
+the "Open Cloud Mesh (OCM) Parameters" group.  This registry records
+the values that MAY appear in the "encryption.scheme" field of a
+[Share Creation Notification](#share-creation-notification).
+
+   Registration Policy: Specification Required [RFC8126]
+
+   Initial Contents:
+
+~~~
+   +=========+============+===============+
+   | Scheme  | Share Type | Reference     |
+   +=========+============+===============+
+   | ocm-pgp | user       | This document |
+   | ocm-pgp | group      | This document |
+   +=========+============+===============+
 ~~~
 
 # Security Considerations

--- a/IETF-OCM.md
+++ b/IETF-OCM.md
@@ -1092,6 +1092,17 @@ described in [OCM-IP].
   share does not expire.  A sender server MAY use it to signal that
   the resource represents a cached copy of a dataset that was made
   available for an efficient data transfer to the destination server.
+* OPTIONAL encryption (object)
+  Optional JSON object with encryption information for the share.  If
+  omitted, it is assumed that the resource is not encrypted.  For
+  encrypted resources, the actual key material is to be exchanged out
+  of band, and this object MUST include:
+  - REQUIRED resourceId (string) - a unique identifier of the
+    underlying resource.
+  - REQUIRED scheme (string) - an identifier of the encryption scheme
+    used to encrypt the resource, such as "ocm-pgp-1".
+  - REQUIRED cipher (string) - the encryption algorithm used to encrypt
+    the resource as in [RFC9180] Section 7.3.
 * REQUIRED protocol (object)
   JSON object with specific options for each protocol.
   The supported protocols are:
@@ -2214,6 +2225,10 @@ https://datatracker.ietf.org/doc/html/rfc9553), May 2024"
 JSON Object Signing and Encryption (JOSE) and CBOR Object Signing
 and Encryption (COSE)](https://datatracker.ietf.org/doc/html/rfc9864)",
 October 2025.
+
+[RFC9180] Barnes, R., Bhargavan, K., Lipp, B. and Wood, C. A.  "[Hybrid
+Public Key Encryption](https://datatracker.ietf.org/doc/html/rfc9180)",
+February 2022.
 
 ## Informative References
 

--- a/spec.yaml
+++ b/spec.yaml
@@ -603,6 +603,31 @@ components:
             server MAY use the `expiration` to signal that the resource represents
             a cached copy of a dataset that was made available for an efficient
             data transfer to the destination server.
+        encryption:
+          type: object
+          description: >
+            Optional object with encryption information for the share. If omitted,
+            it is assumed that the resource is not encrypted, whereas for encrypted
+            resources, the key material has to be exchanged out of band, and this
+            object MUST be present.
+          required:
+            - resourceId
+            - scheme
+            - cipher
+          properties:
+            resourceId:
+              type: string
+              description: >
+                The unique identifier of the underlying resource. This MUST be the same
+                for all shares of the same resource.
+            scheme:
+              type: string
+              description: >
+                An identifier of the encryption scheme used to encrypt the resource.
+            cipher:
+              type: string
+              description: >
+                The encryption algorithm used to encrypt the resource.
         protocol:
           type: object
           description: |

--- a/spec.yaml
+++ b/spec.yaml
@@ -423,18 +423,18 @@ components:
                       Implementations that support receiving SSH shares MUST
                       advertise them here, with an empty object as value.
                 additionalProperties:
-                    oneOf:
-                      - type: string
-                      - type: object
-                    description: >
-                      Any additional protocol supported for this resource type SHOULD
-                      be advertised here, where the value MAY correspond to a top-level
-                      URI to be used for that protocol, or any other relevant
-                      attribute required for that protocol. Similarly, additional
-                      receiving capabilities for custom protocols SHOULD be advertised.
-                      Additional protocols are to be registered in the "OCM Protocols"
-                      registry (see the IANA Considerations section of the OCM
-                      Internet-Draft).
+                  oneOf:
+                    - type: string
+                    - type: object
+                  description: >
+                    Any additional protocol supported for this resource type SHOULD
+                    be advertised here, where the value MAY correspond to a top-level
+                    URI to be used for that protocol, or any other relevant
+                    attribute required for that protocol. Similarly, additional
+                    receiving capabilities for custom protocols SHOULD be advertised.
+                    Additional protocols are to be registered in the "OCM Protocols"
+                    registry (see the IANA Considerations section of the OCM
+                    Internet-Draft).
                 example:
                   webdav: /remote/dav/ocm/
                   webdav-receive: {
@@ -613,7 +613,6 @@ components:
           required:
             - resourceId
             - scheme
-            - cipher
           properties:
             resourceId:
               type: string
@@ -623,11 +622,25 @@ components:
             scheme:
               type: string
               description: >
-                An identifier of the encryption scheme used to encrypt the resource.
-            cipher:
-              type: string
+                An identifier of the encryption scheme used to encrypt the resource, as
+                defined in the OCM IANA registry for encryption schemes. The value MUST
+                be a registered scheme name, such as 'ocm-pgp' or 'ocm-mls'.
+            additionalProperties:
+              type: object
               description: >
-                The encryption algorithm used to encrypt the resource.
+                This object MUST be keyed with the name of the encryption scheme, and its
+                value MUST be a JSON object with additional properties specific to that
+                scheme. For the 'ocm-pgp' scheme, the object MUST contain a 'fingerprints'
+                array of string, with one or more fingerprints of the public keys used to
+                encrypt the resource. For the 'ocm-mls' scheme, the object MUST contain
+                a 'cipher' string with the identifier of the cipher used to encrypt the
+                resource, such as 'AES-256-GCM'.
+          example:
+            resourceId: 7c084226-d9a1-11e6-bf26-cec0c932ce01
+            scheme: ocm-pgp
+            ocm-pgp:
+              fingerprints:
+                - 3F:2A:4B:5C:6D:7E:8F:9A:0B:1C:2D:3E:4F:5A:6B:7C
         protocol:
           type: object
           description: |


### PR DESCRIPTION
Initial attempt at moving the `encryption` object spec without altering the semantic for MLS